### PR TITLE
[Feat] 기본적인 Entity, Response, Exception 기능 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-create-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-create-template.md
@@ -11,4 +11,4 @@ assignees: ''
 
 
 ## Progress 🏃‍♀️
-- []
+- [ ]

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,37 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Spring data JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// JWT -> 원하는 버전 사용
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.hibernate.orm:hibernate-spatial:6.6.9.Final'
+
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/club/model/Club.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/club/model/Club.java
@@ -1,0 +1,30 @@
+package com.WhoIsRoom.WhoIs_Server.domain.club.model;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "clubs")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter @Getter
+public class Club extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", length = 200, nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "club_number", length = 100, nullable = false)
+    private String clubNumber;
+
+    @Builder
+    public Club(String name, String clubNumber) {
+        this.name = name;
+        this.clubNumber = clubNumber;
+    }
+
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/member/model/Member.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/member/model/Member.java
@@ -1,0 +1,41 @@
+package com.WhoIsRoom.WhoIs_Server.domain.member.model;
+
+import com.WhoIsRoom.WhoIs_Server.domain.club.model.Club;
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
+import com.WhoIsRoom.WhoIs_Server.global.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter @Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @Column(name = "is_exist")
+    private Boolean isExist;
+
+    @Builder
+    public Member(User user, Club club, Boolean isExist) {
+        this.user = user;
+        this.club = club;
+        this.isExist = isExist;
+    }
+
+    public void setExist(){
+        this.isExist = true;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/test/controller/TestController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/test/controller/TestController.java
@@ -1,0 +1,28 @@
+package com.WhoIsRoom.WhoIs_Server.domain.test.controller;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.exception.BusinessException;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/test")
+public class TestController {
+
+    @GetMapping("/health-check")
+    public BaseResponse<Void> test() {
+        log.info("=== Test Controller test 진입 ===");
+        return BaseResponse.ok(null);
+    }
+
+    @GetMapping("/error-test")
+    public BaseResponse<Void> errorTest() {
+        log.info("=== Test Controller errorTest 진입 ===");
+        throw new BusinessException(ErrorCode.SERVER_ERROR);
+    }
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
@@ -1,0 +1,33 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.model;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter @Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false)
+    private Long id;
+
+    @Column(name = "email", length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", length = 200, nullable = false)
+    private String password;
+
+    @Column(name = "ninkname", length = 30, nullable = false)
+    private String nickName;
+
+    @Builder
+    public User(String email, String password, String nickName) {
+        this.email = email;
+        this.password = password;
+        this.nickName = nickName;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
@@ -21,7 +21,7 @@ public class User extends BaseEntity {
     @Column(name = "password", length = 200, nullable = false)
     private String password;
 
-    @Column(name = "ninkname", length = 30, nullable = false)
+    @Column(name = "nickname", length = 30, nullable = false)
     private String nickName;
 
     @Builder

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/BusinessException.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.exception;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
@@ -1,0 +1,74 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.exception;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.Objects;
+
+import static com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode.*;
+
+
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    // 요청한 api가 없을 경우
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
+        log.error("[handle_NoHandlerFoundException]", e);
+        return new BaseErrorResponse(NOT_FOUND);
+    }
+
+    // 잘못된 인자를 넘긴 경우 & DTO 검증에 실패한 경우
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({IllegalArgumentException.class, MethodArgumentNotValidException.class, MethodArgumentTypeMismatchException.class, HttpMessageNotReadableException.class, MissingServletRequestParameterException.class})
+    public BaseErrorResponse handle_IllegalArgumentException(Exception e) {
+        log.error("[handle_BadRequest]", e);
+
+        if(e instanceof MethodArgumentNotValidException) {
+            return new BaseErrorResponse(ILLEGAL_ARGUMENT, (Objects.requireNonNull(((MethodArgumentNotValidException) e).getBindingResult().getFieldError()).getDefaultMessage()));
+        }
+
+        return new BaseErrorResponse(ILLEGAL_ARGUMENT);
+    }
+
+    // Http 메서드가 유효하지 않은 경우
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public BaseErrorResponse handle_HttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("[handle_HttpRequestMethodNotSupportedException]", e);
+        return new BaseErrorResponse(METHOD_NOT_ALLOWED);
+    }
+
+    // 런타임 오류가 발생한 경우
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(RuntimeException.class)
+    public BaseErrorResponse handle_RuntimeException(RuntimeException e) {
+        log.error("[handle_RuntimeException]", e);
+        return new BaseErrorResponse(SERVER_ERROR);
+    }
+
+    // 커스텀 에러가 발생한 경우
+    @ExceptionHandler(BusinessException.class)
+    public BaseErrorResponse handleCustomExceptions(BusinessException e) {
+        log.error("[handle_BusinessException]", e);
+        return new BaseErrorResponse(e.getErrorCode());
+    }
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
@@ -66,9 +66,11 @@ public class GlobalControllerAdvice {
 
     // 커스텀 에러가 발생한 경우
     @ExceptionHandler(BusinessException.class)
-    public BaseErrorResponse handleCustomExceptions(BusinessException e) {
+    public ResponseEntity<BaseErrorResponse> handleCustomExceptions(BusinessException e) {
         log.error("[handle_BusinessException]", e);
-        return new BaseErrorResponse(e.getErrorCode());
+        return ResponseEntity
+                .status(e.getErrorCode().getHttpStatus())
+                .body(new BaseErrorResponse(e.getErrorCode()));
     }
 }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/GlobalControllerAdvice.java
@@ -71,5 +71,13 @@ public class GlobalControllerAdvice {
                 .status(e.getErrorCode().getHttpStatus())
                 .body(new BaseErrorResponse(e.getErrorCode()));
     }
+
+    // 예상치 못한 모든 예외가 발생한 경우
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public BaseErrorResponse handle_Exception(Exception e) {
+        log.error("[handle_Exception]", e);
+        return new BaseErrorResponse(SERVER_ERROR);
+    }
 }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/model/BaseEntity.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/model/BaseEntity.java
@@ -1,0 +1,36 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Setter
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BaseStatus status;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.status == null) {
+            this.status = BaseStatus.ACTIVE;
+        }
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/model/BaseStatus.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/model/BaseStatus.java
@@ -1,0 +1,10 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.model;
+
+import lombok.Getter;
+
+@Getter
+public enum BaseStatus {
+
+    ACTIVE,        // 유효한 데이터
+    INACTIVE      // 유효하지 않은 데이터 ( 삭제된 데이터 )
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseErrorResponse.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseErrorResponse.java
@@ -1,0 +1,31 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"success", "status", "message", "timestamp"})
+public class BaseErrorResponse{
+    private final boolean success;
+    private final int status;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public BaseErrorResponse(ErrorCode code) {
+        this.success = false;
+        this.status = code.getHttpStatus();
+        this.message = code.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public BaseErrorResponse(ErrorCode code, String customMessage) {
+        this.success = false;
+        this.status = code.getHttpStatus();
+        this.message = customMessage;
+        this.timestamp = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseResponse.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseResponse.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "data"})
+@JsonPropertyOrder({"success", "status", "message", "data"})
 public class BaseResponse<T> {
 
     private final boolean success;
 
     @Schema(example = "200")
-    private final int code;
+    private final int status;
 
     @Schema(example = "요청에 성공하였습니다.")
     private final String message;
@@ -20,7 +20,7 @@ public class BaseResponse<T> {
 
     private BaseResponse(T data) {
         this.success = true;
-        this.code = HttpStatus.OK.value();
+        this.status = HttpStatus.OK.value();
         this.message = "요청에 성공하였습니다.";
         this.data = data;
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseResponse.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/BaseResponse.java
@@ -1,0 +1,31 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class BaseResponse<T> {
+
+    private final boolean success;
+
+    @Schema(example = "200")
+    private final int code;
+
+    @Schema(example = "요청에 성공하였습니다.")
+    private final String message;
+    private final T data;
+
+    private BaseResponse(T data) {
+        this.success = true;
+        this.code = HttpStatus.OK.value();
+        this.message = "요청에 성공하였습니다.";
+        this.data = data;
+    }
+
+    public static <T> BaseResponse<T> ok(T data) {
+        return new BaseResponse<>(data);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public enum ErrorCode{
+
+    // Common
+    ILLEGAL_ARGUMENT(100, BAD_REQUEST.value(), "잘못된 요청값입니다."),
+    NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
+    METHOD_NOT_ALLOWED(102, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
+    SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다.");
+
+    private final int code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -10,8 +10,6 @@ import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public enum ErrorCode{
 
     // Common

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.WhoIsRoom.WhoIs_Server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/**").permitAll() // 모든 인증 없이 접근 허용
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=WhoIs-Server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       prod: prod-db, prod-port,common
     active: local
 ---
-# ??? DB
+# 로컬용 DB
 spring:
   config:
     activate:
@@ -31,7 +31,7 @@ spring:
       host: localhost
       port: 6379
 ---
-# ??? DB
+# 개발용 DB
 spring:
   config:
     activate:
@@ -46,15 +46,15 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-      format_sql: true
-      show_sql: true
-      highlight_sql: true
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
   data:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
 ---
-# ?? ??
+# 공통 속성
 spring:
   config:
     activate:
@@ -80,7 +80,7 @@ spring:
 #    expiration: ${jwt.refresh.expiration}
 
 ---
-# ??? ??
+# 개발용 포트
 spring:
   config:
     activate:
@@ -88,7 +88,7 @@ spring:
 server:
   port: 8000
 ---
-# ??? ??
+# 배포용 포트
 spring:
   config:
     activate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,97 @@
+spring:
+  application:
+    name: WhoIs-Server
+  profiles:
+    group:
+      local : local-db, local-port, common
+      prod: prod-db, prod-port,common
+    active: local
+---
+# ??? DB
+spring:
+  config:
+    activate:
+      on-profile: local-db
+  datasource:
+    url: ${LOCAL_DATASOURCE_URL}
+    username: ${LOCAL_DATASOURCE_USERNAME}
+    password: ${LOCAL_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        highlight_sql: true
+        dialect: org.hibernate.spatial.dialect.mysql.MySQL56SpatialDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+---
+# ??? DB
+spring:
+  config:
+    activate:
+      on-profile: prod-db
+  datasource:
+    url: ${PROD_DATASOURCE_URL}
+    username: ${PROD_DATASOURCE_USERNAME}
+    password: ${PROD_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+      format_sql: true
+      show_sql: true
+      highlight_sql: true
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+---
+# ?? ??
+spring:
+  config:
+    activate:
+      on-profile: common
+  web:
+    resources:
+      add-mappings: false
+#  mail:
+#    host: smtp.gmail.com
+#    port: 587
+#    username: ${MAIL_USERNAME}
+#    password: ${MAIL_PASSWORD}
+#    properties:
+#      mail.smtp.auth: true
+#      mail.smtp.timeout: 5000
+#      mail.smtp.starttls.enable: true
+#
+#jwt:
+#  secret: ${jwt.secret}
+#  access:
+#    expiration: ${jwt.access.expiration}
+#  refresh:
+#    expiration: ${jwt.refresh.expiration}
+
+---
+# ??? ??
+spring:
+  config:
+    activate:
+      on-profile: local-port
+server:
+  port: 8000
+---
+# ??? ??
+spring:
+  config:
+    activate:
+      on-profile: prod-port
+server:
+  port: 8001


### PR DESCRIPTION
## Related issue 🛠
- Opon #1 

## Work Description 📝
### 모든 Entity 생성
- Club, User, Member(다대다 매핑 테이블)을 만들었습니다. 
- 모두 BaseEntity를 상속받습니다.

### ErrorCode, GlobalExceptionHandler, BusinessException(커스텀 익셉션), BaseErrorResponse와 같은 에러 처리 기능
- ErrorCode, GlobalExceptionHandler, CustomException(커스텀 익셉션), BaseErrorResponse를 모두 구현하였습니다. 

### BaseResponse 생성
- BaseResponse는 제너릭과 static 메서드 (ok 메서드)를 사용하여 편하게 응답할 수 있도록 구현해 놨습니다. 
- BaseStatus는 Active와 INACTIVE로만 만들었습니다.

### application.yml 작성
- dev profile은 필요없다고 판단하여, local, prod로 profile을 구분하였습니다!

## Screenshot 📸
<img width="638" height="320" alt="image" src="https://github.com/user-attachments/assets/aa259ac1-6a1b-4d1d-bb02-f0d07ce298dc" />

<img width="629" height="310" alt="image" src="https://github.com/user-attachments/assets/0ce32b3c-f056-42c6-82e2-31cee75c2668" />


## Uncompleted Tasks 😅

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - API 성공/오류 응답 형식을 표준화한 응답 객체와 전역 예외 처리, 헬스체크 및 오류 테스트 엔드포인트를 추가했습니다.
  - 사용자, 멤버, 클럽 등 기본 도메인 모델과 공통 엔티티(상태·감사 정보)를 도입했습니다.
* **Chores**
  - 데이터베이스, 보안, 문서화, 캐시, 메일, 지리공간, 템플릿 등 빌드 의존성을 대거 추가하고 환경별 설정을 정리했습니다.
  - 기본 보안 구성을 단순화했습니다.
* **Documentation**
  - 이슈 템플릿의 체크박스 마크다운 표기를 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->