### PR TITLE
[Feat] Jwt를 이용한 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// JWT -> 원하는 버전 사용
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/WhoIsServerApplication.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/WhoIsServerApplication.java
@@ -2,7 +2,9 @@ package com.WhoIsRoom.WhoIs_Server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WhoIsServerApplication {
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.controller;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final JwtService jwtService;
+
+    @PostMapping("/logout")
+    public BaseResponse<Void> logout(HttpServletRequest request){
+        jwtService.logout(request);
+        return BaseResponse.ok(null);
+    }
+
+    @PostMapping("/reissue")
+    public BaseResponse<Void> reissueTokens(HttpServletRequest request, HttpServletResponse response) {
+        jwtService.reissueTokens(request, response);
+        return BaseResponse.ok(null);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/LoginRequest.java
@@ -3,8 +3,10 @@ package com.WhoIsRoom.WhoIs_Server.domain.auth.dto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LoginRequest {
     private String email;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.WhoIsRoom.WhoIs_Server.domain.auth.dto;
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/exception/CustomAuthenticationException.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/exception/CustomAuthenticationException.java
@@ -1,0 +1,15 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.exception;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class CustomAuthenticationException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public CustomAuthenticationException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/exception/CustomJwtException.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/exception/CustomJwtException.java
@@ -1,0 +1,15 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.exception;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends JwtException {
+    private final ErrorCode errorCode;
+
+    public CustomJwtException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
@@ -39,23 +39,19 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
         log.info("=== Login Filter (JSON only) 진입 ===");
 
-        // 1) 메서드 강제
         if (!"POST".equalsIgnoreCase(request.getMethod())) {
             throw new AuthenticationServiceException("지원하지 않는 HTTP 메서드입니다.");
         }
 
-        // 2) Content-Type 강제
         String contentType = request.getContentType();
         if (contentType == null || !contentType.toLowerCase().contains("application/json")) {
             throw new AuthenticationServiceException("Content-Type application/json 만 허용됩니다.");
         }
 
-        // 3) JSON 파싱만 try-catch
         LoginRequest login;
         try {
             login = objectMapper.readValue(request.getInputStream(), LoginRequest.class);
         } catch (IOException e) {
-            // ✅ 진짜 파싱 실패만 여기로
             throw new AuthenticationServiceException("JSON 파싱 실패", e);
         }
 
@@ -63,15 +59,12 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         String password = login.getPassword();
 
         if (email == null || email.isBlank() || password == null || password.isBlank()) {
-            // ✅ 자격증명 문제는 그대로 던져서 FailureHandler가 처리
             throw new BadCredentialsException("이메일/비밀번호가 비어있습니다.");
         }
 
         UsernamePasswordAuthenticationToken authToken =
                 new UsernamePasswordAuthenticationToken(email.trim(), password);
 
-        // ✅ 여기서 발생하는 UsernameNotFoundException/BadCredentialsException 등은
-        //    래핑하지 말고 그대로 던진다 → FailureHandler에서 올바른 코드로 매핑됨
         return this.getAuthenticationManager().authenticate(authToken);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
@@ -1,0 +1,58 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomLoginFilter(AuthenticationManager authenticationManager,
+                            ObjectMapper objectMapper,
+                            AuthenticationSuccessHandler successHandler,
+                            AuthenticationFailureHandler failureHandler) {
+        this.objectMapper = objectMapper;
+
+        // 기본 설정들 캡슐화
+        super.setFilterProcessesUrl("/api/login"); // 로그인 엔드포인트 고정
+        super.setUsernameParameter("email");       // username 대신 email
+        super.setPasswordParameter("password");
+
+        // AuthenticationManager + 핸들러 세팅
+        super.setAuthenticationManager(authenticationManager);
+        super.setAuthenticationSuccessHandler(successHandler);
+        super.setAuthenticationFailureHandler(failureHandler);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        //클라이언트 요청에서 username, password 추출
+        String email = obtainUsername(request);
+        String password = obtainPassword(request);
+
+        //스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password, null);
+
+        //token에 담은 검증을 위한 AuthenticationManager로 전달
+        return this.getAuthenticationManager().authenticate(authToken);
+    }
+
+    @Override
+    protected String obtainUsername(HttpServletRequest request) {
+        return request.getParameter("email"); // username 대신 email
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
@@ -40,6 +40,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
 
+        log.info("=== Login Filter 진입 ===");
+
         //클라이언트 요청에서 username, password 추출
         String email = obtainUsername(request);
         String password = obtainPassword(request);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
@@ -27,7 +27,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         this.objectMapper = objectMapper;
 
         // 기본 설정들 캡슐화
-        super.setFilterProcessesUrl("/api/login"); // 로그인 엔드포인트 고정
+        super.setFilterProcessesUrl("/api/auth/login"); // 로그인 엔드포인트 고정
         super.setUsernameParameter("email");       // username 대신 email
         super.setPasswordParameter("password");
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/CustomLoginFilter.java
@@ -1,6 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.filter;
 
-import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.LoginRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.LoginRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
@@ -77,14 +77,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UserPrincipal principal = new UserPrincipal(
                 jwtUtil.getUserId(accessToken),
                 jwtUtil.getName(accessToken),
-                jwtUtil.getEmail(accessToken),
                 null, // 패스워드는 필요 없음
                 jwtUtil.getProviderId(accessToken),
                 authorities
         );
         log.info("UserPrincipal.userId: {}", principal.getUserId());
-        log.info("UserPrincipal.name: {}", principal.getUsername());
-        log.info("UserPrincipal.email: {}", principal.getEmail());
+        log.info("UserPrincipal.nickName: {}", principal.getUsername());
         log.info("UserPrincipal.providerId: {}", principal.getProviderId());
         log.info("UserPrincipal.role: {}", principal.getAuthorities().stream().findFirst().get().toString());
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.filter;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomJwtException;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.model.UserPrincipal;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
@@ -62,7 +63,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 토큰 타입 검사
         if(!"access".equals(jwtUtil.getTokenType(accessToken))) {
-            throw new BadCredentialsException(ErrorCode.INVALID_TOKEN_TYPE.getMessage());
+            throw new CustomJwtException(ErrorCode.INVALID_TOKEN_TYPE);
         }
 
         // 로그아웃 체크
@@ -94,7 +95,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 //            // 소셜 로그인
 //      authToken = new OAuth2AuthenticationToken(principal, authorities, loginProvider);
 //        }
-        log.info("Authentication set in SecurityContext: {}", SecurityContextHolder.getContext().getAuthentication()); // SecurityContext 설정 확인 로깅
+        log.info("Authentication set in SecurityContext: {}", SecurityContextHolder.getContext().getAuthentication());
         log.info("Authorities in SecurityContext: {}", authToken.getAuthorities());
 
         log.info("JWT Filter Success : {}", request.getRequestURI());

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -39,15 +40,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 인증을 안해도 되니 토큰이 필요없는 URL들 (에러: 로그인이 필요합니다)
     public final static List<String> PASS_URIS = Arrays.asList(
-            "/api/login",
-            "/api/logout",
-            "/api/signup"
+            "/api/auth/**"
     );
+
+    private static final AntPathMatcher ANT = new AntPathMatcher();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        if(isPassUris(request.getRequestURI())) {
+        if(isPassUri(request.getRequestURI())) {
             log.info("JWT Filter Passed (pass uri) : {}", request.getRequestURI());
             filterChain.doFilter(request, response);
             return;
@@ -103,7 +104,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private boolean isPassUris(String uri) {
-        return PASS_URIS.contains(uri);
+    private boolean isPassUri(String uri) {
+        return PASS_URIS.stream().anyMatch(pattern -> ANT.match(pattern, uri));
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,103 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.filter;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.model.UserPrincipal;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final JwtService jwtService;
+
+    // 인증을 안해도 되니 토큰이 필요없는 URL들 (에러: 로그인이 필요합니다)
+    public final static List<String> PASS_URIS = Arrays.asList(
+            "/api/login",
+            "/api/logout",
+            "/api/signup"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        if(isPassUris(request.getRequestURI())) {
+            log.info("JWT Filter Passed (pass uri) : {}", request.getRequestURI());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        log.info("Request URI: {}", request.getRequestURI()); // 요청 URI 로깅
+        String accessToken = jwtUtil.resolveAccessToken(request);
+
+        // 엑세스 토큰이 없으면 Authentication도 없음 -> EntryPoint (401)
+        if(accessToken == null) {
+            log.info("JWT Filter Pass (accessToken is null) : {}", request.getRequestURI());
+            SecurityContextHolder.clearContext();
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 토큰 유효성 검사
+        jwtUtil.validateToken(accessToken);
+
+        // 토큰 타입 검사
+        if(!"access".equals(jwtUtil.getTokenType(accessToken))) {
+            throw new JwtException(BaseResponseStatus.INVALID_TOKEN_TYPE);
+        }
+
+        jwtService.checkLogout(request);
+
+        // 권한 리스트 생성
+        List<GrantedAuthority> authorities = Arrays.asList(new SimpleGrantedAuthority(jwtUtil.getRole(accessToken)));
+        log.info("Granted Authorities : {}", authorities);
+        UserPrincipal principal = new UserPrincipal(
+                jwtUtil.getMemberId(accessToken),
+                jwtUtil.getEmail(accessToken),
+                null, // 패스워드는 필요 없음
+                authorities
+        );
+        log.info("UserPrincipal created: {}", principal); // 생성된 사용자 정보 로깅
+        log.info("UserPrincipal.providerId: {}", principal.getProviderId());
+        log.info("UserPrincipal.role: {}", principal.getAuthorities().stream().findFirst().get().toString());
+        log.info("UserPrincipal.memberId: {}", principal.getUserId());
+
+        Authentication authToken = null;
+        if ("localhost".equals(loginProvider)) {
+            // 폼 로그인(자체 회원)
+            authToken = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        }
+//        else {
+//            // 소셜 로그인
+//      authToken = new OAuth2AuthenticationToken(principal, authorities, loginProvider);
+//        }
+        log.info("Authentication set in SecurityContext: {}", SecurityContextHolder.getContext().getAuthentication()); // SecurityContext 설정 확인 로깅
+        log.info("Authorities in SecurityContext: {}", authToken.getAuthorities());
+
+        log.info("JWT Filter Success : {}", request.getRequestURI());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isPassUris(String uri) {
+        return PASS_URIS.contains(uri);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/filter/JwtAuthenticationFilter.java
@@ -40,6 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 인증을 안해도 되니 토큰이 필요없는 URL들 (에러: 로그인이 필요합니다)
     public final static List<String> PASS_URIS = Arrays.asList(
+            "/api/users/signup",
             "/api/auth/**"
     );
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static com.WhoIsRoom.WhoIs_Server.domain.auth.util.SecurityErrorResponseUtil.setErrorResponse;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException{
+
+        log.info("=== AccessDeniedHandler 진입 ===");
+
+        ErrorCode code = ErrorCode.SECURITY_ACCESS_DENIED;
+        setErrorResponse(response, code);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
@@ -21,6 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         log.info("=== AuthenticationEntryPoint 진입 ===");
+
         ErrorCode code = ErrorCode.SECURITY_UNAUTHORIZED;
 
         if (authException instanceof CustomAuthenticationException e) {

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static com.WhoIsRoom.WhoIs_Server.domain.auth.util.SecurityErrorResponseUtil.setErrorResponse;
+
 @Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
@@ -18,12 +21,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         log.info("=== AuthenticationEntryPoint 진입 ===");
-        BaseResponseStatus status = BaseResponseStatus.UNAUTHORIZED_ACCESS;
+        ErrorCode code = ErrorCode.SECURITY_UNAUTHORIZED;
 
         if (authException instanceof CustomAuthenticationException e) {
             code = e.getErrorCode(); // 커스텀 코드 사용
         }
-        setErrorResponse(response, status);
+        setErrorResponse(response, code);
     }
 }
 /**

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
@@ -19,7 +19,7 @@ import static com.WhoIsRoom.WhoIs_Server.domain.auth.util.SecurityErrorResponseU
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException{
         log.info("=== AuthenticationEntryPoint 진입 ===");
 
         ErrorCode code = ErrorCode.SECURITY_UNAUTHORIZED;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.info("=== AuthenticationEntryPoint 진입 ===");
+        BaseResponseStatus status = BaseResponseStatus.UNAUTHORIZED_ACCESS;
+
+        if (authException instanceof CustomAuthenticationException e) {
+            code = e.getErrorCode(); // 커스텀 코드 사용
+        }
+        setErrorResponse(response, status);
+    }
+}
+/**
+ * [CustomAuthenticationEntryPoint]
+ *
+ * 📌 Spring Security에서 인증(Authentication)에 실패했을 때 호출되는 진입점 클래스입니다.
+ *
+ * ✅ 주요 처리 대상:
+ * - Spring Security 내부에서 발생한 AuthenticationException
+ *   (ex. UsernameNotFoundException, BadCredentialsException, 인증 객체 없음 등)
+ *
+ * ✅ 동작 방식:
+ * - 인증되지 않은 사용자가 보호된 리소스에 접근 시
+ * - Spring Security의 ExceptionTranslationFilter가 감지
+ * - 이 EntryPoint의 commence() 메서드가 호출됨
+ * - 401 Unauthorized 상태 코드와 공통 JSON 에러 응답 반환
+ *
+ * ✅ 처리하지 않는 예외:
+ * - 필터 단계에서 발생한 JwtException 은  ExceptionHandlerFilter에서 처리됨
+ **/

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
@@ -1,41 +1,36 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
 
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static com.WhoIsRoom.WhoIs_Server.domain.auth.util.SecurityErrorResponseUtil.setErrorResponse;
+
+@Slf4j
 @Component
 public class CustomJsonAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest req, HttpServletResponse res,
-                                        AuthenticationException ex) throws IOException {
-        res.setContentType("application/json;charset=UTF-8");
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException authenticationException) throws IOException {
+        log.info("=== AuthenticationFailureHandler 진입 ===");
 
-        int http = HttpServletResponse.SC_UNAUTHORIZED; // 401 기본
-        String code = "INVALID_CREDENTIALS";
-        String message = "이메일 또는 비밀번호가 올바르지 않습니다.";
+        ErrorCode code = ErrorCode.INVALID_ID_OR_PASSWORD;
 
-        if (ex instanceof UsernameNotFoundException) {
-            code = "USER_NOT_FOUND";
-            message = ex.getMessage();
-        } else if (ex instanceof LockedException) {
-            http = 423; code = "ACCOUNT_LOCKED"; message = "잠긴 계정입니다.";
-        } else if (ex instanceof DisabledException) {
-            http = 403; code = "ACCOUNT_DISABLED"; message = "비활성화된 계정입니다.";
-        } else if (ex instanceof AccountExpiredException) {
-            http = 403; code = "ACCOUNT_EXPIRED"; message = "만료된 계정입니다.";
-        } else if (ex instanceof CredentialsExpiredException) {
-            code = "CREDENTIALS_EXPIRED"; message = "비밀번호가 만료되었습니다.";
+        if (authenticationException instanceof UsernameNotFoundException) {
+            code = ErrorCode.USER_NOT_FOUND;
         }
-
-        res.setStatus(http);
-        res.getWriter().write("""
-        {"success":false,"code":"%s","message":"%s"}
-        """.formatted(code, message));
+        setErrorResponse(response, code);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
@@ -1,0 +1,41 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJsonAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest req, HttpServletResponse res,
+                                        AuthenticationException ex) throws IOException {
+        res.setContentType("application/json;charset=UTF-8");
+
+        int http = HttpServletResponse.SC_UNAUTHORIZED; // 401 기본
+        String code = "INVALID_CREDENTIALS";
+        String message = "이메일 또는 비밀번호가 올바르지 않습니다.";
+
+        if (ex instanceof UsernameNotFoundException) {
+            code = "USER_NOT_FOUND";
+            message = ex.getMessage();
+        } else if (ex instanceof LockedException) {
+            http = 423; code = "ACCOUNT_LOCKED"; message = "잠긴 계정입니다.";
+        } else if (ex instanceof DisabledException) {
+            http = 403; code = "ACCOUNT_DISABLED"; message = "비활성화된 계정입니다.";
+        } else if (ex instanceof AccountExpiredException) {
+            http = 403; code = "ACCOUNT_EXPIRED"; message = "만료된 계정입니다.";
+        } else if (ex instanceof CredentialsExpiredException) {
+            code = "CREDENTIALS_EXPIRED"; message = "비밀번호가 만료되었습니다.";
+        }
+
+        res.setStatus(http);
+        res.getWriter().write("""
+        {"success":false,"code":"%s","message":"%s"}
+        """.formatted(code, message));
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
@@ -4,10 +4,7 @@ import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.AccountExpiredException;
-import org.springframework.security.authentication.CredentialsExpiredException;
-import org.springframework.security.authentication.DisabledException;
-import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
@@ -24,13 +21,43 @@ public class CustomJsonAuthenticationFailureHandler implements AuthenticationFai
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException authenticationException) throws IOException {
-        log.info("=== AuthenticationFailureHandler 진입 ===");
+        log.warn("=== AuthenticationFailureHandler 진입: type={}, msg={} ===",
+                authenticationException.getClass().getSimpleName(), authenticationException.getMessage());
 
-        ErrorCode code = ErrorCode.INVALID_ID_OR_PASSWORD;
-
-        if (authenticationException instanceof UsernameNotFoundException) {
-            code = ErrorCode.USER_NOT_FOUND;
-        }
+        ErrorCode code = mapToErrorCode(authenticationException);
         setErrorResponse(response, code);
+    }
+
+    private ErrorCode mapToErrorCode(AuthenticationException ex) {
+
+        // 1) 아이디 없음
+        if (ex instanceof UsernameNotFoundException) {
+            return ErrorCode.USER_NOT_FOUND;
+        }
+
+        // 2) 잘못된 자격 증명(값 누락/불일치)
+        if (ex instanceof BadCredentialsException) {
+            return ErrorCode.INVALID_ID_OR_PASSWORD;
+        }
+
+        // 4) 요청 형식/메서드/파싱 문제 (JSON only 강제)
+        if (ex instanceof AuthenticationServiceException) {
+            String msg = ex.getMessage() != null ? ex.getMessage() : "";
+
+            if (msg.contains("HTTP 메서드")) {
+                return ErrorCode.METHOD_NOT_ALLOWED;
+            }
+            if (msg.contains("Content-Type")) {
+                return ErrorCode.ILLEGAL_ARGUMENT;
+            }
+            if (msg.contains("파싱")) {
+                return ErrorCode.ILLEGAL_ARGUMENT;
+            }
+            // 그 외 서비스 예외는 일단 잘못된 요청으로 처리
+            return ErrorCode.ILLEGAL_ARGUMENT;
+        }
+
+        // 5) 그 외 디폴트
+        return ErrorCode.ILLEGAL_ARGUMENT;
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/JwtExceptionHandlerFilter.java
@@ -1,0 +1,33 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomJwtException;
+import com.WhoIsRoom.WhoIs_Server.global.common.exception.BusinessException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.WhoIsRoom.WhoIs_Server.domain.auth.util.SecurityErrorResponseUtil.setErrorResponse;
+
+@Slf4j
+@Component
+public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("=== JwtExceptionHandlerFilter 진입 ===");
+
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomJwtException e) {
+            setErrorResponse(response, e.getErrorCode());
+        } catch (BusinessException e) {
+            setErrorResponse(response, e.getErrorCode());
+        }
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -36,11 +36,12 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String providerId = authenticationUtil.getProviderId();
         String role = authenticationUtil.getRole();
         Long memberId = authenticationUtil.getMemberId();
+        String nickName = authenticationUtil.getUsername();
         log.info("[CustomAuthenticationSuccessHandler] providerId={}, role={}, memberId={}", providerId, role, memberId);
 
         // 토큰 생성
-        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role);
-        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId);
+        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role, nickName);
+        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId, nickName);
 
         // refresh token 저장
         jwtService.storeRefreshToken(refreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -36,13 +36,11 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String providerId = authenticationUtil.getProviderId();
         String role = authenticationUtil.getRole();
         Long memberId = authenticationUtil.getMemberId();
-        String userName = authenticationUtil.getUsername();
-        String email = authenticationUtil.getEmail();
-        log.info("[CustomAuthenticationSuccessHandler] providerId={}, role={}, memberId={}, email={}", providerId, role, memberId, email);
+        log.info("[CustomAuthenticationSuccessHandler] providerId={}, role={}, memberId={}", providerId, role, memberId);
 
         // 토큰 생성
-        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role, userName, email);
-        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId, role, email);
+        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role);
+        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId);
 
         // refresh token 저장
         jwtService.storeRefreshToken(refreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -1,12 +1,17 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.success;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response.LoginResponse;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.AuthenticationUtil;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseErrorResponse;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -22,6 +27,7 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final AuthenticationUtil authenticationUtil;
     private final JwtUtil jwtUtil;
     private final JwtService jwtService;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
@@ -43,5 +49,18 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         log.info("[CustomAuthenticationSuccessHandler], refreshToken={}", refreshToken);
 
         jwtService.sendTokens(response, accessToken, refreshToken);
+
+        LoginResponse data = LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+
+        BaseResponse<LoginResponse> body = BaseResponse.ok(data);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(response.getWriter(), body);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -35,14 +35,13 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         log.info("[CustomAuthenticationSuccessHandler] providerId={}, role={}, memberId={}, email={}", providerId, role, memberId, email);
 
         // 토큰 생성
-        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role, userName);
-        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId, role);
+        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role, userName, email);
+        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId, role, email);
 
         // refresh token 저장
         jwtService.storeRefreshToken(refreshToken);
         log.info("[CustomAuthenticationSuccessHandler], refreshToken={}", refreshToken);
 
-        // 리다이렉션
-        response.sendRedirect(LOGIN_SUCCESS_URI);
+        jwtService.sendTokens(response, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.success;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.util.AuthenticationUtil;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,47 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.handler.success;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthenticationUtil authenticationUtil;
+    private final JwtUtil jwtUtil;
+    private final JwtService jwtService;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        String providerId = authenticationUtil.getProviderId();
+        String role = authenticationUtil.getRole();
+        Long memberId = authenticationUtil.getMemberId();
+        String userName = authenticationUtil.getUsername();
+        String email = authenticationUtil.getEmail();
+        log.info("[CustomAuthenticationSuccessHandler] providerId={}, role={}, memberId={}, email={}", providerId, role, memberId, email);
+
+        // 토큰 생성
+        String accessToken = jwtUtil.createAccessToken(memberId, providerId, role, userName);
+        String refreshToken = jwtUtil.createRefreshToken(memberId, providerId, role);
+
+        // refresh token 저장
+        jwtService.storeRefreshToken(refreshToken);
+        log.info("[CustomAuthenticationSuccessHandler], refreshToken={}", refreshToken);
+
+        // 리다이렉션
+        response.sendRedirect(LOGIN_SUCCESS_URI);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
@@ -1,0 +1,38 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.model;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class UserPrincipal implements UserDetails{
+
+    private final Long userId;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    /** UserDetails 구현 */
+    @Override
+    public String getPassword() { return password; }
+
+    @Override
+    public String getUsername() { return username; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
@@ -1,17 +1,21 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.model;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 
+@Getter
 @RequiredArgsConstructor
 public class UserPrincipal implements UserDetails{
 
     private final Long userId;
     private final String username;
+    private final String email;
     private final String password;
+    private final String providerId;
     private final Collection<? extends GrantedAuthority> authorities;
 
     /** UserDetails 구현 */

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/model/UserPrincipal.java
@@ -13,7 +13,6 @@ public class UserPrincipal implements UserDetails{
 
     private final Long userId;
     private final String username;
-    private final String email;
     private final String password;
     private final String providerId;
     private final Collection<? extends GrantedAuthority> authorities;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.Role;
 
 import java.util.Collections;
 
@@ -25,9 +26,10 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException(email + "해당 이메일의 사용자를 찾을 수 없습니다."));
 
         return new UserPrincipal(
+                user.getId(),
                 user.getEmail(),
                 user.getPassword(),
-                Collections.singleton(new SimpleGrantedAuthority(Role.USER.name()))
+                Collections.singleton(new SimpleGrantedAuthority(Role.MEMBER.getValue()))
         );
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.model.UserPrincipal;
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Collections;
+
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserPrincipal loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email);
+        if (user == null) {
+            throw new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다.");
+        }
+
+        return new UserPrincipal(
+                user.getEmail(),
+                user.getPassword(),
+                Collections.singleton(new SimpleGrantedAuthority(Role.USER.name()))
+        );
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -2,21 +2,27 @@ package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.model.UserPrincipal;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
+import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
+
     private final UserRepository userRepository;
 
     @Override
     public UserPrincipal loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email);
-        if (user == null) {
-            throw new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다.");
-        }
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(email + "해당 이메일의 사용자를 찾을 수 없습니다."));
 
         return new UserPrincipal(
                 user.getEmail(),

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -28,7 +28,6 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new UserPrincipal(
                 user.getId(),
                 user.getNickName(),
-                user.getEmail(),
                 user.getPassword(),
                 "localhost",
                 Collections.singleton(user.getRole().toAuthority())

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -27,8 +27,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         return new UserPrincipal(
                 user.getId(),
+                user.getNickName(),
                 user.getEmail(),
                 user.getPassword(),
+                "localhost",
                 Collections.singleton(user.getRole().toAuthority())
         );
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/CustomUserDetailsService.java
@@ -23,13 +23,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserPrincipal loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException(email + "해당 이메일의 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException(email + ": 해당 이메일의 사용자를 찾을 수 없습니다."));
 
         return new UserPrincipal(
                 user.getId(),
                 user.getEmail(),
                 user.getPassword(),
-                Collections.singleton(new SimpleGrantedAuthority(Role.MEMBER.getValue()))
+                Collections.singleton(user.getRole().toAuthority())
         );
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -7,11 +7,9 @@ import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -51,7 +49,7 @@ public class JwtService {
         invalidAccessToken(accessToken);
     }
 
-    public void reissueToken(HttpServletRequest request, HttpServletResponse response) {
+    public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = jwtUtil.extractRefreshToken(request)
                 .orElseThrow(() -> new CustomAuthenticationException(ErrorCode.SECURITY_INVALID_REFRESH_TOKEN));
         jwtUtil.validateToken(refreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -82,8 +82,8 @@ public class JwtService {
     private void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {
 
         // 새로운 Refresh Token 발급
-        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken));
-        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken));
+        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getName(refreshToken));
+        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getName(refreshToken));
 
         // 새로운 Refresh Token을 DB나 Redis에 저장
         storeRefreshToken(reissuedRefreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -52,7 +52,11 @@ public class JwtService {
     public void reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = jwtUtil.extractRefreshToken(request)
                 .orElseThrow(() -> new CustomAuthenticationException(ErrorCode.SECURITY_INVALID_REFRESH_TOKEN));
+
         jwtUtil.validateToken(refreshToken);
+        if (!"refresh".equals(jwtUtil.getTokenType(refreshToken))) {
+            throw new CustomJwtException(ErrorCode.INVALID_TOKEN_TYPE);
+        }
         reissueAndSendTokens(response, refreshToken);
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -82,8 +82,8 @@ public class JwtService {
     private void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {
 
         // 새로운 Refresh Token 발급
-        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getName(refreshToken), jwtUtil.getEmail(refreshToken));
-        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getEmail(refreshToken));
+        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken));
+        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken));
 
         // 새로운 Refresh Token을 DB나 Redis에 저장
         storeRefreshToken(reissuedRefreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -25,10 +25,10 @@ public class JwtService {
     @Value("${jwt.refresh.expiration}")
     private Long REFRESH_TOKEN_EXPIRED_IN;
 
-    @Value("$jwt.access.header")
+    @Value("${jwt.access.header}")
     private String ACCESS_HEADER;
 
-    @Value("$jwt.refresh.header")
+    @Value("${jwt.refresh.header}")
     private String REFRESH_HEADER;
 
     private static final String LOGOUT_VALUE = "logout";

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,6 +1,7 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomJwtException;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
@@ -60,7 +61,7 @@ public class JwtService {
 
     private void deleteRefreshToken(String refreshToken){
         if(refreshToken == null){
-            throw new JwtException(BaseResponseStatus.EMPTY_REFRESH_HEADER);
+            throw new CustomJwtException(BaseResponseStatus.EMPTY_REFRESH_HEADER);
         }
         redisService.delete(refreshToken);
     }
@@ -73,8 +74,8 @@ public class JwtService {
     private void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {
 
         // 새로운 Refresh Token 발급
-        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getMemberId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getName(refreshToken));
-        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getMemberId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken));
+        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getName(refreshToken));
+        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getUserId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken));
 
         // 새로운 Refresh Token을 DB나 Redis에 저장
         storeRefreshToken(reissuedRefreshToken);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,13 +17,11 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class JwtService {
 
-    @Getter
     @Value("${jwt.access.expiration}")
-    private Long accessTokenExpirationPeriod;
+    private Long ACCESS_TOKEN_EXPIRED_IN;
 
-    @Getter
     @Value("${jwt.refresh.expiration}")
-    private Long refreshTokenExpirationPeriod;
+    private Long REFRESH_TOKEN_EXPIRED_IN;
 
     private static final String LOGOUT_VALUE = "logout";
     private static final String REFRESH_TOKEN_KEY_PREFIX = "auth:refresh:";
@@ -54,7 +53,7 @@ public class JwtService {
     }
 
     public void storeRefreshToken(String refreshToken) {
-        redisService.setValues(REFRESH_TOKEN_KEY_PREFIX, refreshToken, Duration.ofMillis(refreshTokenExpirationPeriod));
+        redisService.setValues(REFRESH_TOKEN_KEY_PREFIX, refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRED_IN));
     }
 
     private void deleteRefreshToken(String refreshToken){
@@ -66,7 +65,7 @@ public class JwtService {
 
     private void invalidAccessToken(String accessToken) {
         redisService.setValues(accessToken, LOGOUT_VALUE,
-                Duration.ofMillis(accessTokenExpirationPeriod));
+                Duration.ofMillis(ACCESS_TOKEN_EXPIRED_IN));
     }
 
     private void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
+import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,0 +1,91 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    @Getter
+    @Value("${jwt.access.expiration}")
+    private Long accessTokenExpirationPeriod;
+
+    @Getter
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshTokenExpirationPeriod;
+
+    private static final String LOGOUT_VALUE = "logout";
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "auth:refresh:";
+
+    private final RedisService redisService;
+    private final JwtUtil jwtUtil;
+
+    public void logout(HttpServletRequest request) {
+        String accessToken = jwtUtil.resolveAccessToken(request);
+        String refreshToken = jwtUtil.resolveRefreshToken(request);
+
+        deleteRefreshToken(refreshToken);
+        //access token blacklist 처리 -> 로그아웃한 사용자가 요청 시 access token이 redis에 존재하면 jwtAuthenticationFilter에서 인증처리 거부
+        invalidAccessToken(accessToken);
+    }
+
+    public void reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtUtil.resolveRefreshToken(request);
+        jwtUtil.validateToken(refreshToken);
+        reissueAndSendTokens(response, refreshToken);
+    }
+
+    public void checkLogout(HttpServletRequest request) {
+        String accessToken = jwtUtil.resolveAccessToken(request);
+        String value = redisService.getValues(accessToken);
+        if (value.equals(LOGOUT_VALUE)) {
+            throw new LogoutException(BaseResponseStatus.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    public void storeRefreshToken(String refreshToken) {
+        redisService.setValues(REFRESH_TOKEN_KEY_PREFIX, refreshToken, Duration.ofMillis(refreshTokenExpirationPeriod));
+    }
+
+    private void deleteRefreshToken(String refreshToken){
+        if(refreshToken == null){
+            throw new JwtException(BaseResponseStatus.EMPTY_REFRESH_HEADER);
+        }
+        redisService.delete(refreshToken);
+    }
+
+    private void invalidAccessToken(String accessToken) {
+        redisService.setValues(accessToken, LOGOUT_VALUE,
+                Duration.ofMillis(accessTokenExpirationPeriod));
+    }
+
+    private void reissueAndSendTokens(HttpServletResponse response, String refreshToken) {
+
+        // 새로운 Refresh Token 발급
+        String reissuedAccessToken = jwtUtil.createAccessToken(jwtUtil.getMemberId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken), jwtUtil.getName(refreshToken));
+        String reissuedRefreshToken = jwtUtil.createRefreshToken(jwtUtil.getMemberId(refreshToken), jwtUtil.getProviderId(refreshToken), jwtUtil.getRole(refreshToken));
+
+        // 새로운 Refresh Token을 DB나 Redis에 저장
+        storeRefreshToken(reissuedRefreshToken);
+
+        // 기존 Refresh Token 폐기 (DB나 Redis에서 삭제)
+        deleteRefreshToken(refreshToken);
+
+        sendTokens(response, reissuedAccessToken, reissuedRefreshToken);
+    }
+
+    private void sendTokens(HttpServletResponse response, String reissuedAccessToken,
+                            String reissuedRefreshToken) {
+        response.addCookie(cookieUtil.createCookie(accessHeader, reissuedAccessToken));
+        response.addCookie(cookieUtil.createCookie(refreshHeader, reissuedRefreshToken));
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,13 +1,16 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -44,8 +47,7 @@ public class JwtService {
         reissueAndSendTokens(response, refreshToken);
     }
 
-    public void checkLogout(HttpServletRequest request) {
-        String accessToken = jwtUtil.resolveAccessToken(request);
+    public void checkLogout(String accessToken) {
         String value = redisService.getValues(accessToken);
         if (value.equals(LOGOUT_VALUE)) {
             throw new LogoutException(BaseResponseStatus.UNAUTHORIZED_ACCESS);

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/AuthenticationUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/AuthenticationUtil.java
@@ -1,0 +1,46 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.util;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.model.UserPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+@Component
+public class AuthenticationUtil {
+
+    public String getProviderId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getProviderId();
+    }
+
+    public String getRole() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority grantedAuthority = iterator.next();
+        return grantedAuthority.getAuthority();
+    }
+
+    public Long getMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getUserId();
+    }
+
+    public String getUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getUsername();
+    }
+
+    public String getEmail(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getEmail();
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/AuthenticationUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/AuthenticationUtil.java
@@ -38,9 +38,9 @@ public class AuthenticationUtil {
         return principal.getUsername();
     }
 
-    public String getEmail(){
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
-        return principal.getEmail();
-    }
+//    public String getEmail(){
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+//        return principal.getEmail();
+//    }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -67,12 +67,13 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createAccessToken(Long userId, String providerId, String role) {
+    public String createAccessToken(Long userId, String providerId, String role, String name) {
 
         return Jwts.builder()
                 .claim("tokenType", "access")
                 .claim("userId", userId)
                 .claim("providerId", providerId)
+                .claim("name", name)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRED_IN))
@@ -80,12 +81,13 @@ public class JwtUtil {
                 .compact();
     }
 
-    public String createRefreshToken(Long userId, String providerId) {
+    public String createRefreshToken(Long userId, String providerId, String name) {
 
         return Jwts.builder()
                 .claim("tokenType", "refresh")
                 .claim("userId", userId)
                 .claim("providerId", providerId)
+                .claim("name", name)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRED_IN))
                 .signWith(secretKey, Jwts.SIG.HS256)

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 @Component
 public class JwtUtil {
 
-    @Value("${jwt.secret}")
-    private SecretKey secretKey;
+    private final SecretKey secretKey;
 
     @Value("${jwt.access.expiration}")
     private Long ACCESS_TOKEN_EXPIRED_IN;
@@ -29,7 +28,7 @@ public class JwtUtil {
 
     public final String BEARER = "Bearer ";
 
-    public JwtUtil(@Value("${secret.jwt-secret-key}") String secret) {
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -26,14 +26,20 @@ public class JwtUtil {
     @Value("${jwt.refresh.expiration}")
     private Long REFRESH_TOKEN_EXPIRED_IN;
 
+    @Value("$jwt.access.header")
+    private String ACCESS_HEADER;
+
+    @Value("$jwt.refresh.header")
+    private String REFRESH_HEADER;
+
     public final String BEARER = "Bearer ";
 
     public JwtUtil(@Value("${jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public Long getMemberId(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
+    public Long getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
     }
 
     public String getProviderId(String token) {
@@ -60,11 +66,11 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createAccessToken(Long memberId, String providerId, String role, String name) {
+    public String createAccessToken(Long userId, String providerId, String role, String name) {
 
         return Jwts.builder()
                 .claim("tokenType", "access")
-                .claim("memberId", memberId)
+                .claim("userId", userId)
                 .claim("providerId", providerId)
                 .claim("role", role)
                 .claim("name", name)
@@ -74,11 +80,11 @@ public class JwtUtil {
                 .compact();
     }
 
-    public String createRefreshToken(Long memberId, String providerId, String role) {
+    public String createRefreshToken(Long userId, String providerId, String role) {
 
         return Jwts.builder()
                 .claim("tokenType", "refresh")
-                .claim("memberId", memberId)
+                .claim("userId", userId)
                 .claim("providerId", providerId)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
@@ -113,14 +119,14 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
     }
 
-    public Optional<String> extractAccessToken(HttpServletRequest request, String accessHeader) {
-        return Optional.ofNullable(request.getHeader(accessHeader))
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_HEADER))
                 .filter(accessToken -> accessToken.startsWith(BEARER))
                 .map(accessToken -> accessToken.replace(BEARER, ""));
     }
 
-    public Optional<String> extractRefreshToken(HttpServletRequest request, String refreshHeader) {
-        return Optional.ofNullable(request.getHeader(refreshHeader))
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(REFRESH_HEADER))
                 .filter(refreshToken -> refreshToken.startsWith(BEARER))
                 .map(refreshToken -> refreshToken.replace(BEARER, ""));
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -67,32 +67,28 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createAccessToken(Long userId, String providerId, String role, String name, String email) {
+    public String createAccessToken(Long userId, String providerId, String role) {
 
         return Jwts.builder()
                 .claim("tokenType", "access")
                 .claim("userId", userId)
                 .claim("providerId", providerId)
                 .claim("role", role)
-                .claim("name", name)
-                .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRED_IN))
-                .signWith(secretKey)
+                .signWith(secretKey, Jwts.SIG.HS256)
                 .compact();
     }
 
-    public String createRefreshToken(Long userId, String providerId, String role, String email) {
+    public String createRefreshToken(Long userId, String providerId) {
 
         return Jwts.builder()
                 .claim("tokenType", "refresh")
                 .claim("userId", userId)
                 .claim("providerId", providerId)
-                .claim("role", role)
-                .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRED_IN))
-                .signWith(secretKey)
+                .signWith(secretKey, Jwts.SIG.HS256)
                 .compact();
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.util;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomJwtException;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -101,17 +102,17 @@ public class JwtUtil {
                     .parseSignedClaims(token)
                     .getPayload();
         } catch (ExpiredJwtException e) { // 토큰 만료
-            throw new JwtException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+            throw new CustomJwtException(ErrorCode.EXPIRED_ACCESS_TOKEN);
         } catch (UnsupportedJwtException e) { // 지원되지 않는 형식
-            throw new JwtException(ErrorCode.UNSUPPORTED_TOKEN_TYPE);
+            throw new CustomJwtException(ErrorCode.UNSUPPORTED_TOKEN_TYPE);
         } catch (MalformedJwtException e) { // 구조가 잘못된 토큰
-            throw new JwtException(ErrorCode.MALFORMED_TOKEN_TYPE);
+            throw new CustomJwtException(ErrorCode.MALFORMED_TOKEN_TYPE);
         } catch (SignatureException e) { // 서명 위조 (곧 지원 중단)
-            throw new JwtException(ErrorCode.INVALID_SIGNATURE_JWT);
+            throw new CustomJwtException(ErrorCode.INVALID_SIGNATURE_JWT);
         } catch (IllegalArgumentException e) { // 토큰이 비어 있거나 Null
-            throw new JwtException(ErrorCode.EMPTY_AUTHORIZATION_HEADER);
+            throw new CustomJwtException(ErrorCode.EMPTY_AUTHORIZATION_HEADER);
         } catch (Exception e) { // 기타 예외 상황
-            throw new JwtException(ErrorCode.INVALID_ACCESS_TOKEN);
+            throw new CustomJwtException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -27,10 +27,10 @@ public class JwtUtil {
     @Value("${jwt.refresh.expiration}")
     private Long REFRESH_TOKEN_EXPIRED_IN;
 
-    @Value("$jwt.access.header")
+    @Value("${jwt.access.header}")
     private String ACCESS_HEADER;
 
-    @Value("$jwt.refresh.header")
+    @Value("${jwt.refresh.header}")
     private String REFRESH_HEADER;
 
     public final String BEARER_PREFIX = "Bearer ";

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
     @Value("$jwt.refresh.header")
     private String REFRESH_HEADER;
 
-    public final String BEARER = "Bearer ";
+    public final String BEARER_PREFIX = "Bearer ";
 
     public JwtUtil(@Value("${jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
@@ -124,13 +124,13 @@ public class JwtUtil {
 
     public Optional<String> extractAccessToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(ACCESS_HEADER))
-                .filter(accessToken -> accessToken.startsWith(BEARER))
-                .map(accessToken -> accessToken.replace(BEARER, ""));
+                .filter(accessToken -> accessToken.startsWith(BEARER_PREFIX))
+                .map(accessToken -> accessToken.replace(BEARER_PREFIX, ""));
     }
 
     public Optional<String> extractRefreshToken(HttpServletRequest request) {
         return Optional.ofNullable(request.getHeader(REFRESH_HEADER))
-                .filter(refreshToken -> refreshToken.startsWith(BEARER))
-                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+                .filter(refreshToken -> refreshToken.startsWith(BEARER_PREFIX))
+                .map(refreshToken -> refreshToken.replace(BEARER_PREFIX, ""));
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -1,0 +1,128 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.util;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.*;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private SecretKey secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private Long ACCESS_TOKEN_EXPIRED_IN;
+
+    @Value("${jwt.refresh.expiration}")
+    private Long REFRESH_TOKEN_EXPIRED_IN;
+
+    public final String BEARER = "Bearer ";
+
+    public JwtUtil(@Value("${secret.jwt-secret-key}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public Long getMemberId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("memberId", Long.class);
+    }
+
+    public String getProviderId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("providerId", String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public String getTokenType(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("tokenType", String.class);
+    }
+
+    public String getEmail(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    public String getName(String token){
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
+    }
+
+    public Boolean isTokenExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createAccessToken(Long memberId, String providerId, String role, String name) {
+
+        return Jwts.builder()
+                .claim("tokenType", "access")
+                .claim("memberId", memberId)
+                .claim("providerId", providerId)
+                .claim("role", role)
+                .claim("name", name)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRED_IN))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId, String providerId, String role) {
+
+        return Jwts.builder()
+                .claim("tokenType", "refresh")
+                .claim("memberId", memberId)
+                .claim("providerId", providerId)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRED_IN))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public void validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) { // 토큰 만료
+            throw new JwtException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (UnsupportedJwtException e) { // 지원되지 않는 형식
+            throw new JwtException(ErrorCode.UNSUPPORTED_TOKEN_TYPE);
+        } catch (MalformedJwtException e) { // 구조가 잘못된 토큰
+            throw new JwtException(ErrorCode.MALFORMED_TOKEN_TYPE);
+        } catch (SignatureException e) { // 서명 위조 (곧 지원 중단)
+            throw new JwtException(ErrorCode.INVALID_SIGNATURE_JWT);
+        } catch (IllegalArgumentException e) { // 토큰이 비어 있거나 Null
+            throw new JwtException(ErrorCode.EMPTY_AUTHORIZATION_HEADER);
+        } catch (Exception e) { // 기타 예외 상황
+            throw new JwtException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public String getUserNameFromToken(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
+    }
+
+    public Optional<String> extractAccessToken(HttpServletRequest request, String accessHeader) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(accessToken -> accessToken.startsWith(BEARER))
+                .map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractRefreshToken(HttpServletRequest request, String refreshHeader) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -67,7 +67,7 @@ public class JwtUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createAccessToken(Long userId, String providerId, String role, String name) {
+    public String createAccessToken(Long userId, String providerId, String role, String name, String email) {
 
         return Jwts.builder()
                 .claim("tokenType", "access")
@@ -75,19 +75,21 @@ public class JwtUtil {
                 .claim("providerId", providerId)
                 .claim("role", role)
                 .claim("name", name)
+                .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRED_IN))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public String createRefreshToken(Long userId, String providerId, String role) {
+    public String createRefreshToken(Long userId, String providerId, String role, String email) {
 
         return Jwts.builder()
                 .claim("tokenType", "refresh")
                 .claim("userId", userId)
                 .claim("providerId", providerId)
                 .claim("role", role)
+                .claim("email", email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRED_IN))
                 .signWith(secretKey)
@@ -112,7 +114,7 @@ public class JwtUtil {
         } catch (IllegalArgumentException e) { // 토큰이 비어 있거나 Null
             throw new CustomJwtException(ErrorCode.EMPTY_AUTHORIZATION_HEADER);
         } catch (Exception e) { // 기타 예외 상황
-            throw new CustomJwtException(ErrorCode.INVALID_ACCESS_TOKEN);
+            throw new CustomJwtException(ErrorCode.SECURITY_INVALID_ACCESS_TOKEN);
         }
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/SecurityErrorResponseUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/SecurityErrorResponseUtil.java
@@ -1,0 +1,25 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.util;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseErrorResponse;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class SecurityErrorResponseUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+    public static void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        BaseErrorResponse errorResponse = new BaseErrorResponse(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/SecurityErrorResponseUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/SecurityErrorResponseUtil.java
@@ -10,7 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class SecurityErrorResponseUtil {
-    private static final ObjectMapper objectMapper = new ObjectMapper()
+    public static final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/controller/UserController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/controller/UserController.java
@@ -1,9 +1,12 @@
 package com.WhoIsRoom.WhoIs_Server.domain.user.controller;
 
+import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.user.service.UserService;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,8 +19,8 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public BaseResponse<Void> signUp(User user) {
-        userService.signUp();
+    public BaseResponse<Void> signUp(@RequestBody SignupRequest request) {
+        userService.signUp(request);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/controller/UserController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.controller;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public BaseResponse<Void> signUp(User user) {
+        userService.signUp();
+        return BaseResponse.ok(null);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/dto/request/SignupRequest.java
@@ -1,0 +1,13 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignupRequest {
+    private String email;
+    private String nickName;
+    private String password;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/Role.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/Role.java
@@ -1,0 +1,39 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.model;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Optional;
+
+@Getter
+public enum Role {
+
+    MEMBER("MEMBER"),
+    ADMIN("ADMIN");
+
+    Role(String value) {
+        this.value = value;
+        this.role = PREFIX + value;
+    }
+
+    private static final String PREFIX = "ROLE_";
+    private final String value;
+    private final String role;
+
+    // 파싱된 값에 맞는 Role을 반환하는 메서드
+    public static Optional<Role> fromRole(String roleString) {
+        if (roleString != null && roleString.startsWith(PREFIX)) {
+            String roleValue = roleString.substring(PREFIX.length());
+            for (Role r : values()) {
+                if (r.value.equalsIgnoreCase(roleValue)) return Optional.of(r);
+            }
+        }
+        return Optional.empty();
+    }
+
+    // Role을 권한으로 변환하는 메서드
+    public GrantedAuthority toAuthority() {
+        return new SimpleGrantedAuthority(PREFIX + this.value);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
@@ -24,10 +24,15 @@ public class User extends BaseEntity {
     @Column(name = "nickname", length = 30, nullable = false)
     private String nickName;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Builder
-    public User(String email, String password, String nickName) {
+    public User(String email, String password, String nickName, Role role) {
         this.email = email;
         this.password = password;
         this.nickName = nickName;
+        this.role = role;
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/model/User.java
@@ -21,7 +21,7 @@ public class User extends BaseEntity {
     @Column(name = "password", length = 200, nullable = false)
     private String password;
 
-    @Column(name = "nickname", length = 30, nullable = false)
+    @Column(name = "nickname", length = 50, nullable = false, unique = true)
     private String nickName;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.repository;
+
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -1,12 +1,14 @@
 package com.WhoIsRoom.WhoIs_Server.domain.user.service;
 
 import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.Role;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
 import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
 import com.WhoIsRoom.WhoIs_Server.global.common.exception.BusinessException;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void signUp(SignupRequest request) {
@@ -28,7 +31,8 @@ public class UserService {
         User user = User.builder()
                 .email(request.getEmail())
                 .nickName(request.getNickName())
-                .password(request.getPassword())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(Role.MEMBER)
                 .build();
         userRepository.save(user);
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -1,0 +1,35 @@
+package com.WhoIsRoom.WhoIs_Server.domain.user.service;
+
+import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
+import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
+import com.WhoIsRoom.WhoIs_Server.global.common.exception.BusinessException;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void signUp(SignupRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new BusinessException(ErrorCode.USER_DUPLICATE_EMAIL);
+        }
+        if (userRepository.existsByNickName(request.getNickName())) {
+            throw new BusinessException(ErrorCode.USER_DUPLICATE_NICKNAME);
+        }
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .nickName(request.getNickName())
+                .password(request.getPassword())
+                .build();
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/redis/RedisService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/redis/RedisService.java
@@ -1,0 +1,39 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    protected boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/resolver/CurrentUserId.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/resolver/CurrentUserId.java
@@ -1,0 +1,12 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/resolver/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/resolver/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.WhoIsRoom.WhoIs_Server.global.common.resolver;
+
+import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
+import com.WhoIsRoom.WhoIs_Server.global.common.exception.BusinessException;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(CurrentUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+
+        String email = (String) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .getId();
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -16,7 +16,22 @@ public enum ErrorCode{
     ILLEGAL_ARGUMENT(100, BAD_REQUEST.value(), "잘못된 요청값입니다."),
     NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
     METHOD_NOT_ALLOWED(102, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
-    SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다.");
+    SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다."),
+
+    // Auth
+    SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),
+    INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "토큰 타입이 유효하지 않습니다."),
+    SECURITY_INVALID_REFRESH_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "refresh token이 유효하지 않습니다."),
+    SECURITY_INVALID_ACCESS_TOKEN(603, HttpStatus.UNAUTHORIZED.value(), "access token이 유효하지 않습니다."),
+    SECURITY_ACCESS_DENIED(604, HttpStatus.UNAUTHORIZED.value(), "접근 권한이 없습니다."),
+    REFRESH_TOKEN_REQUIRED(605, BAD_REQUEST.value(), "refresh token이 필요합니다."),
+    MAIL_SEND_FAILED(606, BAD_REQUEST.value(), "메일 전송에 실패했습니다."),
+    INVALID_EMAIL_CODE(607, BAD_REQUEST.value(), "인증 번호가 다릅니다."),
+    EXPIRED_EMAIL_CODE(608, BAD_REQUEST.value(), "인증 번호가 만료되었거나 없습니다."),
+    AUTHCODE_ALREADY_AUTHENTICATED(609, BAD_REQUEST.value(), "이미 인증이 된 번호입니다."),
+    AUTHCODE_UNAUTHORIZED(610, HttpStatus.UNAUTHORIZED.value(), "이메일 인증을 하지 않았습니다."),
+    LOGIN_FAILED(611, BAD_REQUEST.value(), "이메일 혹은 비밀번호가 올바르지 않습니다.");
+
 
     private final int code;
     private final int httpStatus;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -24,13 +24,18 @@ public enum ErrorCode{
     SECURITY_INVALID_REFRESH_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "refresh token이 유효하지 않습니다."),
     SECURITY_INVALID_ACCESS_TOKEN(603, HttpStatus.UNAUTHORIZED.value(), "access token이 유효하지 않습니다."),
     SECURITY_ACCESS_DENIED(604, HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
-    REFRESH_TOKEN_REQUIRED(605, BAD_REQUEST.value(), "refresh token이 필요합니다."),
-    MAIL_SEND_FAILED(606, BAD_REQUEST.value(), "메일 전송에 실패했습니다."),
-    INVALID_EMAIL_CODE(607, BAD_REQUEST.value(), "인증 번호가 다릅니다."),
-    EXPIRED_EMAIL_CODE(608, BAD_REQUEST.value(), "인증 번호가 만료되었거나 없습니다."),
-    AUTHCODE_ALREADY_AUTHENTICATED(609, BAD_REQUEST.value(), "이미 인증이 된 번호입니다."),
+    EMPTY_REFRESH_HEADER(605, HttpStatus.BAD_REQUEST.value(), "refresh token이 필요합니다."),
+    MAIL_SEND_FAILED(606, HttpStatus.BAD_REQUEST.value(), "메일 전송에 실패했습니다."),
+    INVALID_EMAIL_CODE(607, HttpStatus.BAD_REQUEST.value(), "인증 번호가 다릅니다."),
+    EXPIRED_EMAIL_CODE(608, HttpStatus.BAD_REQUEST.value(), "인증 번호가 만료되었거나 없습니다."),
+    AUTHCODE_ALREADY_AUTHENTICATED(609, HttpStatus.BAD_REQUEST.value(), "이미 인증이 된 번호입니다."),
     AUTHCODE_UNAUTHORIZED(610, HttpStatus.UNAUTHORIZED.value(), "이메일 인증을 하지 않았습니다."),
-    LOGIN_FAILED(611, BAD_REQUEST.value(), "이메일 혹은 비밀번호가 올바르지 않습니다.");
+    LOGIN_FAILED(611, HttpStatus.BAD_REQUEST.value(), "이메일 혹은 비밀번호가 올바르지 않습니다."),
+    EMPTY_AUTHORIZATION_HEADER(612, HttpStatus.BAD_REQUEST.value(),"Authorization 헤더가 존재하지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(613, HttpStatus.BAD_REQUEST.value(), "이미 만료된 Access 토큰입니다."),
+    UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.BAD_REQUEST.value(),"지원되지 않는 토큰 형식입니다."),
+    MALFORMED_TOKEN_TYPE(615, HttpStatus.BAD_REQUEST.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
+    INVALID_SIGNATURE_JWT(616, HttpStatus.BAD_REQUEST.value(), "인증 시그니처가 올바르지 않습니다");
 
 
     private final int code;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -18,6 +18,9 @@ public enum ErrorCode{
     METHOD_NOT_ALLOWED(102, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
     SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다."),
 
+    // User
+    USER_NOT_FOUND(200, HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
+
     // Auth
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),
     INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "토큰 타입이 유효하지 않습니다."),
@@ -35,7 +38,8 @@ public enum ErrorCode{
     EXPIRED_ACCESS_TOKEN(613, HttpStatus.BAD_REQUEST.value(), "이미 만료된 Access 토큰입니다."),
     UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.BAD_REQUEST.value(),"지원되지 않는 토큰 형식입니다."),
     MALFORMED_TOKEN_TYPE(615, HttpStatus.BAD_REQUEST.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
-    INVALID_SIGNATURE_JWT(616, HttpStatus.BAD_REQUEST.value(), "인증 시그니처가 올바르지 않습니다");
+    INVALID_SIGNATURE_JWT(616, HttpStatus.BAD_REQUEST.value(), "인증 시그니처가 올바르지 않습니다"),
+    INVALID_ID_OR_PASSWORD(617, HttpStatus.BAD_REQUEST.value(), "이메일 또는 비밀번호가 올바르지 않습니다.");
 
 
     private final int code;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -23,7 +23,7 @@ public enum ErrorCode{
     INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "토큰 타입이 유효하지 않습니다."),
     SECURITY_INVALID_REFRESH_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "refresh token이 유효하지 않습니다."),
     SECURITY_INVALID_ACCESS_TOKEN(603, HttpStatus.UNAUTHORIZED.value(), "access token이 유효하지 않습니다."),
-    SECURITY_ACCESS_DENIED(604, HttpStatus.UNAUTHORIZED.value(), "접근 권한이 없습니다."),
+    SECURITY_ACCESS_DENIED(604, HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
     REFRESH_TOKEN_REQUIRED(605, BAD_REQUEST.value(), "refresh token이 필요합니다."),
     MAIL_SEND_FAILED(606, BAD_REQUEST.value(), "메일 전송에 실패했습니다."),
     INVALID_EMAIL_CODE(607, BAD_REQUEST.value(), "인증 번호가 다릅니다."),

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -13,13 +13,15 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorCode{
 
     // Common
-    ILLEGAL_ARGUMENT(100, BAD_REQUEST.value(), "잘못된 요청값입니다."),
+    ILLEGAL_ARGUMENT(100, HttpStatus.BAD_REQUEST.value(), "잘못된 요청값입니다."),
     NOT_FOUND(101, HttpStatus.NOT_FOUND.value(), "존재하지 않는 API 입니다."),
     METHOD_NOT_ALLOWED(102, HttpStatus.METHOD_NOT_ALLOWED.value(), "유효하지 않은 Http 메서드입니다."),
-    SERVER_ERROR(103, INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다."),
+    SERVER_ERROR(103, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버에 오류가 발생했습니다."),
 
     // User
     USER_NOT_FOUND(200, HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
+    USER_DUPLICATE_EMAIL(201, HttpStatus.BAD_REQUEST.value(), "중복된 이메일의 시용자가 있습니다."),
+    USER_DUPLICATE_NICKNAME(202, HttpStatus.BAD_REQUEST.value(), "중복된 닉네임의 사용자가 있습니다."),
 
     // Auth
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/CorsConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.WhoIsRoom.WhoIs_Server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*"); // 모든 출처 허용
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        configuration.addAllowedHeader("*"); // 모든 헤더 허용
+        configuration.setAllowCredentials(true); // 인증 정보 허용
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/RedisConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package com.WhoIsRoom.WhoIs_Server.global.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @PostConstruct
+    public void init() {
+        log.info("Redis Host: {}", host);
+        log.info("Redis Port: {}", port);
+    }
+
+    // RedisProperties로 yaml에 저장한 host, post를 연결
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    // serializer 설정으로 redis-cli를 통해 직접 데이터를 조회할 수 있도록 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/RedisConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/RedisConfig.java
@@ -33,11 +33,11 @@ public class RedisConfig {
 
     // serializer 설정으로 redis-cli를 통해 직접 데이터를 조회할 수 있도록 설정
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         return redisTemplate;
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -1,21 +1,71 @@
 package com.WhoIsRoom.WhoIs_Server.global.config;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    // Custom한 것들은 Component로 주입하기 (싱글턴 Bean)
+    // private final CustomOAuth2UserService customOuth2UserService;
+    private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final FilterExceptionHandler filterExceptionHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
+                .cors(cors -> cors.disable())
                 .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable());
+
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(filterExceptionHandler, JwtAuthenticationFilter.class);
+
+        http
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler)
+                );
+
+        http
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/**").permitAll() // 모든 인증 없이 접근 허용
+                        .requestMatchers("/**").permitAll()
+                        // 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 );
+
+        // 일반 ID/비밀번호 로그인 설정
+        http
+                .formLogin(formLogin -> formLogin
+                        .loginPage("/login")
+                        .loginProcessingUrl("/login-process") // 로그인 폼 제출 처리 URL
+                        .usernameParameter("email")
+                        .passwordParameter("password")
+                        .successHandler(customAuthenticationSuccessHandler) // 일반 로그인도 동일한 성공 핸들러 사용
+                        .permitAll() // 로그인 페이지는 모두 접근 가능
+                );
+
+        // OAuth2 소셜 로그인 설정
+//        http
+//                .oauth2Login(oauth2Login -> oauth2Login
+//                        .loginPage("/login")
+//                        .userInfoEndpoint(userInfo -> userInfo
+//                                .userService(customOAuth2UserService) // OAuth2 사용자 정보 처리
+//                        )
+//                        .successHandler(customAuthenticationSuccessHandler) // 소셜 로그인도 동일한 성공 핸들러 사용
+//                );
         return http.build();
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.WhoIsRoom.WhoIs_Server.global.config;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.JwtAuthenticationFilter;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAccessDeniedHandler;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAuthenticationEntryPoint;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.JwtExceptionHandlerFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +22,7 @@ public class SecurityConfig {
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final FilterExceptionHandler filterExceptionHandler;
+    private final JwtExceptionHandlerFilter filterExceptionHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -16,6 +16,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -46,7 +48,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
-                .addFilterBefore(jwtExceptionHandlerFilter, JwtAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(customLoginFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -90,5 +92,10 @@ public class SecurityConfig {
                 customAuthenticationSuccessHandler,
                 customJsonAuthenticationFailureHandler
         );
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.WhoIsRoom.WhoIs_Server.global.config;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.JwtAuthenticationFilter;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -1,15 +1,21 @@
 package com.WhoIsRoom.WhoIs_Server.global.config;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.CustomLoginFilter;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.JwtAuthenticationFilter;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAccessDeniedHandler;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAuthenticationEntryPoint;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomJsonAuthenticationFailureHandler;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.JwtExceptionHandlerFilter;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.success.CustomAuthenticationSuccessHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -21,44 +27,42 @@ public class SecurityConfig {
     // Custom한 것들은 Component로 주입하기 (싱글턴 Bean)
     // private final CustomOAuth2UserService customOuth2UserService;
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
+    private final CustomJsonAuthenticationFailureHandler customJsonAuthenticationFailureHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
+    private final AuthenticationConfiguration configuration;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomLoginFilter customLoginFilter) throws Exception {
         http
-                .cors(cors -> cors.disable())
+                // 기본 옵션, 폼 로그인 비활성화
                 .csrf(csrf -> csrf.disable())
-                .httpBasic(httpBasic -> httpBasic.disable());
+                .cors(cors -> cors.disable())
+                .httpBasic(b -> b.disable())
+                .formLogin(fl -> fl.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
+                .addFilterBefore(jwtExceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtExceptionHandlerFilter, JwtAuthenticationFilter.class);
+                .addFilterAt(customLoginFilter, UsernamePasswordAuthenticationFilter.class);
 
         http
+                // 시큐리티 표준 예외 핸들러 (401/403)
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                         .accessDeniedHandler(customAccessDeniedHandler)
                 );
 
         http
+                // 인가 규칙
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/**").permitAll()
                         // 나머지 모든 요청은 인증 필요
                         .anyRequest().authenticated()
-                );
-
-        // 일반 ID/비밀번호 로그인 설정
-        http
-                .formLogin(formLogin -> formLogin
-                        .loginPage("/login")
-                        .loginProcessingUrl("/login-process") // 로그인 폼 제출 처리 URL
-                        .usernameParameter("email")
-                        .passwordParameter("password")
-                        .successHandler(customAuthenticationSuccessHandler) // 일반 로그인도 동일한 성공 핸들러 사용
-                        .permitAll() // 로그인 페이지는 모두 접근 가능
                 );
 
         // OAuth2 소셜 로그인 설정
@@ -71,5 +75,20 @@ public class SecurityConfig {
 //                        .successHandler(customAuthenticationSuccessHandler) // 소셜 로그인도 동일한 성공 핸들러 사용
 //                );
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CustomLoginFilter customLoginFilter() throws Exception {
+        return new CustomLoginFilter(
+                authenticationManager(),
+                objectMapper,
+                customAuthenticationSuccessHandler,
+                customJsonAuthenticationFailureHandler
+        );
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.WhoIsRoom.WhoIs_Server.domain.auth.filter.JwtAuthenticationFilter;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAccessDeniedHandler;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.CustomAuthenticationEntryPoint;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.exception.JwtExceptionHandlerFilter;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.handler.success.CustomAuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,7 +23,7 @@ public class SecurityConfig {
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final JwtExceptionHandlerFilter filterExceptionHandler;
+    private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -34,7 +35,7 @@ public class SecurityConfig {
 
         http
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(filterExceptionHandler, JwtAuthenticationFilter.class);
+                .addFilterBefore(jwtExceptionHandlerFilter, JwtAuthenticationFilter.class);
 
         http
                 .exceptionHandling(exception -> exception

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
-                .addFilterBefore(jwtExceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionHandlerFilter, JwtAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterAt(customLoginFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/WebConfig.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.WhoIsRoom.WhoIs_Server.global.config;
+
+import com.WhoIsRoom.WhoIs_Server.global.common.resolver.CurrentUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserIdArgumentResolver CurrentUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(CurrentUserIdArgumentResolver);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,8 +76,10 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access:
     expiration: ${JWT_ACCESS_EXPIRED_IN}
+    header: Authorization
   refresh:
     expiration: ${JWT_REFRESH_EXPIRED_IN}
+    header: Authorization-refresh
 
 ---
 # 개발용 포트

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,11 +73,11 @@ spring:
 #      mail.smtp.starttls.enable: true
 #
 jwt:
-  secret: "DB2643999CDE219D555A492B4767A4517ACD96AB6C846111E9FE8C79E3"
+  secret: ${JWT_SECRET_KEY}
   access:
-    expiration: 3600000
+    expiration: ${JWT_ACCESS_EXPIRED_IN}
   refresh:
-    expiration: 1209600000
+    expiration: ${JWT_REFRESH_EXPIRED_IN}
 
 ---
 # 개발용 포트

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,12 +72,12 @@ spring:
 #      mail.smtp.timeout: 5000
 #      mail.smtp.starttls.enable: true
 #
-#jwt:
-#  secret: ${jwt.secret}
-#  access:
-#    expiration: ${jwt.access.expiration}
-#  refresh:
-#    expiration: ${jwt.refresh.expiration}
+jwt:
+  secret: "DB2643999CDE219D555A492B4767A4517ACD96AB6C846111E9FE8C79E3"
+  access:
+    expiration: 3600000
+  refresh:
+    expiration: 1209600000
 
 ---
 # 개발용 포트


### PR DESCRIPTION
## Related issue 🛠
- closed #3 

## Work Description 📝
### CustomLoginFilter를 통한 로그인 기능 구현 
### Redis를 이용한 로그아웃, 토큰 재발급 기능 구현 
### JwtAuthentication을 통한 인증 필터 구현 
### EntryPoint, ExceptionHandlerFilter, FailureHandler, deniedHandler를 통한 예외 처리 구현 
### 회원가입 기능 구현 
### Resolver를 통한 CurrentUserId 구현
### Cors 설정  

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] 재발급 시 refersh Token의 로테이션 기능

## To Reviewers 📢
- 현재 토큰의 통신 방법에 대한 회의가 필요할 것 같습니다! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 이메일/비밀번호 로그인(JSON) 및 액세스·리프레시 토큰 발급(로그인 성공 응답 토큰)
  - 토큰 재발급 및 로그아웃 API
  - 회원가입 API 추가
  - 표준화된 보안 오류 응답 및 인증/인가 실패 처리(커스텀 핸들러/필터)
  - 컨트롤러에서 현재 사용자 ID 주입 지원(ArgumentResolver)

- 구성
  - JWT 기반 보안 필터 체인 및 커스텀 로그인 필터 통합, CORS 전역 허용
  - Redis로 리프레시 토큰 및 로그아웃 상태 관리
  - 비밀번호 인코딩 적용
  - 로컬 DB 스키마를 create로 변경, JWT 설정 활성화

- 작업
  - JWT 라이브러리 버전 업그레이드(0.11.5 → 0.12.3)
  - JPA 감사 기능 활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->