### PR TITLE
[Feat] 메일 인증 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### .env file ###
+*.env
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -25,13 +25,16 @@ public class AuthController {
     private final UserService userService;
 
     @PostMapping("/logout")
-    public BaseResponse<Void> logout(HttpServletRequest request, @RequestBody RefreshTokenRequest tokenRequest){
+    public BaseResponse<Void> logout(HttpServletRequest request,
+                                     @RequestBody RefreshTokenRequest tokenRequest){
         jwtService.logout(request, tokenRequest);
         return BaseResponse.ok(null);
     }
 
     @PostMapping("/reissue")
-    public BaseResponse<Void> reissueTokens(HttpServletRequest request, HttpServletResponse response, @RequestBody RefreshTokenRequest tokenRequest) {
+    public BaseResponse<Void> reissueTokens(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            @RequestBody RefreshTokenRequest tokenRequest) {
         jwtService.reissueTokens(request, response, tokenRequest);
         return BaseResponse.ok(null);
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.WhoIsRoom.WhoIs_Server.domain.auth.controller;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.RefreshTokenRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response.ReissueResponse;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.service.UserService;
@@ -32,11 +33,9 @@ public class AuthController {
     }
 
     @PostMapping("/reissue")
-    public BaseResponse<Void> reissueTokens(HttpServletRequest request,
-                                            HttpServletResponse response,
-                                            @RequestBody RefreshTokenRequest tokenRequest) {
-        jwtService.reissueTokens(request, response, tokenRequest);
-        return BaseResponse.ok(null);
+    public BaseResponse<ReissueResponse> reissueTokens(@RequestBody RefreshTokenRequest tokenRequest) {
+        ReissueResponse response = jwtService.reissueTokens(tokenRequest);
+        return BaseResponse.ok(response);
     }
 
     @PostMapping("/email/send")

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
+import com.WhoIsRoom.WhoIs_Server.domain.user.service.UserService;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ public class AuthController {
 
     private final JwtService jwtService;
     private final MailService mailService;
+    private final UserService userService;
 
     @PostMapping("/logout")
     public BaseResponse<Void> logout(HttpServletRequest request){
@@ -42,6 +44,12 @@ public class AuthController {
     @PostMapping("/email/validation")
     public BaseResponse<Void> checkAuthCode(@RequestBody CodeCheckRequest request) {
         mailService.checkAuthCode(request);
+        return BaseResponse.ok(null);
+    }
+
+    @PostMapping("/email/find-password")
+    public BaseResponse<Void> findPassword(@RequestBody MailRequest request) {
+        userService.updateMyPassword(request);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -2,15 +2,15 @@ package com.WhoIsRoom.WhoIs_Server.domain.auth.controller;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.PasswordRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.RefreshTokenRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response.ReissueResponse;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.service.UserService;
+import com.WhoIsRoom.WhoIs_Server.global.common.resolver.CurrentUserId;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -52,7 +52,14 @@ public class AuthController {
 
     @PostMapping("/email/find-password")
     public BaseResponse<Void> findPassword(@RequestBody MailRequest request) {
-        userService.updateMyPassword(request);
+        userService.sendNewPassword(request);
+        return BaseResponse.ok(null);
+    }
+
+    @PatchMapping("/password")
+    public BaseResponse<Void> updatePassword(@CurrentUserId Long userId,
+                                             @RequestBody PasswordRequest request) {
+        userService.updateMyPassword(userId, request);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -1,15 +1,16 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.controller;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final JwtService jwtService;
+    private final MailService mailService;
 
     @PostMapping("/logout")
     public BaseResponse<Void> logout(HttpServletRequest request){
@@ -28,6 +30,18 @@ public class AuthController {
     @PostMapping("/reissue")
     public BaseResponse<Void> reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         jwtService.reissueTokens(request, response);
+        return BaseResponse.ok(null);
+    }
+
+    @PostMapping("/email/send")
+    public BaseResponse<Void> sendAuthCodeMail(@RequestBody MailRequest request) {
+        mailService.sendMail(request);
+        return BaseResponse.ok(null);
+    }
+
+    @PostMapping("/email/validation")
+    public BaseResponse<Void> checkAuthCode(@RequestBody CodeCheckRequest request) {
+        mailService.checkAuthCode(request);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.WhoIsRoom.WhoIs_Server.domain.auth.controller;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.RefreshTokenRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.JwtService;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.service.UserService;
@@ -24,14 +25,14 @@ public class AuthController {
     private final UserService userService;
 
     @PostMapping("/logout")
-    public BaseResponse<Void> logout(HttpServletRequest request){
-        jwtService.logout(request);
+    public BaseResponse<Void> logout(HttpServletRequest request, @RequestBody RefreshTokenRequest tokenRequest){
+        jwtService.logout(request, tokenRequest);
         return BaseResponse.ok(null);
     }
 
     @PostMapping("/reissue")
-    public BaseResponse<Void> reissueTokens(HttpServletRequest request, HttpServletResponse response) {
-        jwtService.reissueTokens(request, response);
+    public BaseResponse<Void> reissueTokens(HttpServletRequest request, HttpServletResponse response, @RequestBody RefreshTokenRequest tokenRequest) {
+        jwtService.reissueTokens(request, response, tokenRequest);
         return BaseResponse.ok(null);
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/CodeCheckRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/CodeCheckRequest.java
@@ -1,0 +1,15 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CodeCheckRequest {
+    private String email;
+    private String authCode;
+}
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/MailRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/MailRequest.java
@@ -1,0 +1,13 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MailRequest {
+    private String email;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/PasswordRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/PasswordRequest.java
@@ -1,0 +1,12 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordRequest {
+    private String prePassword;
+    private String newPassword;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshTokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/response/ReissueResponse.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/dto/response/ReissueResponse.java
@@ -1,0 +1,11 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReissueResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/success/CustomAuthenticationSuccessHandler.java
@@ -47,8 +47,6 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         jwtService.storeRefreshToken(refreshToken);
         log.info("[CustomAuthenticationSuccessHandler], refreshToken={}", refreshToken);
 
-        jwtService.sendTokens(response, accessToken, refreshToken);
-
         LoginResponse data = LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
@@ -112,7 +112,7 @@ public class MailService {
     public String setContext(String authCode) {
         Context context = new Context();
         context.setVariable("code", authCode);
-        return templateEngine.process("authCode-email.html", context);
+        return templateEngine.process("AuthCode-email.html", context);
     }
 }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
@@ -1,0 +1,117 @@
+package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
+
+import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
+import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
+import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
+import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.time.Duration;
+import java.util.Random;
+
+@Slf4j
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private static final long VERIFICATION_CODE_EXPIRY_MINUTES = 5;
+
+    private static final long VERIFIED_TTL_SECONDS = 1800; // 30분
+
+    private static final String EMAIL_KEY_PREFIX = "auth:email:";
+
+    private final JavaMailSender javaMailSender;
+
+    private final SpringTemplateEngine templateEngine;
+
+    private final UserRepository userRepository;
+
+    private final RedisService redisService;
+
+    public void sendMail(MailRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new CustomAuthenticationException(ErrorCode.USER_DUPLICATE_EMAIL);
+        }
+
+        String authCode = createCode();
+        MimeMessage mimeMessage = createEmailMessage(request.getEmail(), authCode);
+
+        try {
+            javaMailSender.send(mimeMessage);
+
+            String key = EMAIL_KEY_PREFIX + request.getEmail();
+            redisService.setValues(key, authCode, Duration.ofMinutes(VERIFICATION_CODE_EXPIRY_MINUTES));
+        } catch (MailException e) {  //JavaMailSender의 전송과정에서 오류 발생 시
+            throw new CustomAuthenticationException(ErrorCode.MAIL_SEND_FAILED);
+        }
+    }
+
+    // 인증 번호 6자리를 구현하는 메서드
+    public String createCode() {
+        Random random = new Random();
+        StringBuilder key = new StringBuilder();
+
+        for (int i = 0; i < 6; i++) {
+            key.append(random.nextInt(10)); // 0~9 숫자
+        }
+
+        return key.toString();
+    }
+
+    private MimeMessage createEmailMessage(String recipient, String authCode) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+            mimeMessageHelper.setTo(recipient);
+            mimeMessageHelper.setSubject("[BARO] 이메일 인증을 위한 인증 코드 발송");
+            mimeMessageHelper.setText(setContext(authCode), true);
+
+            return mimeMessage;
+        } catch (MessagingException e) {  // SMTP 전송 오류, 포맷 오류 발생 시
+            throw new CustomAuthenticationException(ErrorCode.MAIL_SEND_FAILED);
+        }
+    }
+
+    public void checkAuthCode(CodeCheckRequest request) {
+        String storedCode = getStoredCode(request.getEmail());
+        if (storedCode == null) {
+            throw new CustomAuthenticationException(ErrorCode.EXPIRED_EMAIL_CODE);
+        }
+
+        // 인증 번호가 이미 인증된 상태인 경우 그냥 리턴
+        if ("VERIFIED".equals(getStoredCode(request.getEmail()))){return;};
+
+        // 입력 코드와 Redis 코드가 다르면 에러
+        if (!String.valueOf(request.getAuthCode()).equals(storedCode)) {
+            throw new CustomAuthenticationException(ErrorCode.INVALID_EMAIL_CODE);
+        }
+        // 인증 성공: 값 변경 + TTL 재설정
+        redisService.setValues(EMAIL_KEY_PREFIX + request.getEmail(), "VERIFIED", Duration.ofSeconds(VERIFIED_TTL_SECONDS));
+    }
+
+    public String getStoredCode(String email) {
+        String key = EMAIL_KEY_PREFIX + email;
+        return redisService.getValues(key);
+    }
+
+    // thymeleaf를 통한 html 적용
+    public String setContext(String authCode) {
+        Context context = new Context();
+        context.setVariable("code", authCode);
+        return templateEngine.process("authCode-email.html", context);
+    }
+}
+
+

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.CodeCheckRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
 import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/MailService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
 import com.WhoIsRoom.WhoIs_Server.domain.user.repository.UserRepository;
 import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.user.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.Role;
@@ -43,9 +44,10 @@ public class UserService {
     }
 
     @Transactional
-    public void updateMyPassword(Long userId, String password) {
-        User user = userRepository.findById(userId)
+    public void updateMyPassword(MailRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-        user.setPassword(passwordEncoder.encode(password));
+        String newPassword = mailService.sendPasswordMail(request);
+        user.setPassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.WhoIsRoom.WhoIs_Server.domain.user.service;
 
+import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.Role;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.User;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
 
     @Transactional
     public void signUp(SignupRequest request) {
@@ -26,6 +28,9 @@ public class UserService {
         }
         if (userRepository.existsByNickName(request.getNickName())) {
             throw new BusinessException(ErrorCode.USER_DUPLICATE_NICKNAME);
+        }
+        if (!"VERIFIED".equals(mailService.getStoredCode(request.getEmail()))){
+            throw new BusinessException(ErrorCode.AUTHCODE_UNAUTHORIZED);
         }
 
         User user = User.builder()

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.WhoIsRoom.WhoIs_Server.domain.user.service;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.MailRequest;
+import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.PasswordRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.service.MailService;
 import com.WhoIsRoom.WhoIs_Server.domain.user.dto.request.SignupRequest;
 import com.WhoIsRoom.WhoIs_Server.domain.user.model.Role;
@@ -44,10 +45,21 @@ public class UserService {
     }
 
     @Transactional
-    public void updateMyPassword(MailRequest request) {
+    public void sendNewPassword(MailRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         String newPassword = mailService.sendPasswordMail(request);
         user.setPassword(passwordEncoder.encode(newPassword));
+    }
+
+    @Transactional
+    public void updateMyPassword(Long userId, PasswordRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(request.getPrePassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -41,4 +41,11 @@ public class UserService {
                 .build();
         userRepository.save(user);
     }
+
+    @Transactional
+    public void updateMyPassword(Long userId, String password) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.setPassword(passwordEncoder.encode(password));
+    }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/BusinessException.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/exception/BusinessException.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 
-    public BusinessException(ErrorCode errorCode) {
-        this.errorCode = errorCode;
+    public BusinessException(ErrorCode code) {
+        super(code.getMessage());
+        this.errorCode = code;
     }
 }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -41,8 +41,8 @@ public enum ErrorCode{
     UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.BAD_REQUEST.value(),"지원되지 않는 토큰 형식입니다."),
     MALFORMED_TOKEN_TYPE(615, HttpStatus.BAD_REQUEST.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
     INVALID_SIGNATURE_JWT(616, HttpStatus.BAD_REQUEST.value(), "인증 시그니처가 올바르지 않습니다"),
-    INVALID_ID_OR_PASSWORD(617, HttpStatus.BAD_REQUEST.value(), "이메일 또는 비밀번호가 올바르지 않습니다.");
-
+    INVALID_ID_OR_PASSWORD(617, HttpStatus.BAD_REQUEST.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_PASSWORD(618, HttpStatus.BAD_REQUEST.value(), "기존 비밀번호가 유효하지 않습니다");
 
     private final int code;
     private final int httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   profiles:
     group:
       local : local-db, local-port, common
-      prod: prod-db, prod-port,common
+      prod: prod-db, prod-port, common
     active: local
 ---
 # 로컬용 DB
@@ -59,6 +59,7 @@ spring:
   config:
     activate:
       on-profile: common
+    import: optional:file:.env[.properties]
   web:
     resources:
       add-mappings: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,16 +62,16 @@ spring:
   web:
     resources:
       add-mappings: false
-#  mail:
-#    host: smtp.gmail.com
-#    port: 587
-#    username: ${MAIL_USERNAME}
-#    password: ${MAIL_PASSWORD}
-#    properties:
-#      mail.smtp.auth: true
-#      mail.smtp.timeout: 5000
-#      mail.smtp.starttls.enable: true
-#
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_ADDRESS}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.timeout: 5000
+      mail.smtp.starttls.enable: true
+
 jwt:
   secret: ${JWT_SECRET_KEY}
   access:

--- a/src/main/resources/templates/AuthCode-email.html
+++ b/src/main/resources/templates/AuthCode-email.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 동아리에 누가 있는지 알려주는 동방에누구입니다.</h1>
+    <br>
+    <p> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 회원가입 인증 번호 입니다. </h3>
+        <div style="font-size:130%" th:text="${code}"> </div>
+    </div>
+    <br/>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/Password-email.html
+++ b/src/main/resources/templates/Password-email.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 동아리에 누가 있는지 알려주는 동방에누구입니다.</h1>
+    <br>
+    <p> 임시 비밀번호가 다음과 같이 변경되었습니다.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 임시 비밀번호 입니다. </h3>
+        <div style="font-size:130%" th:text="${password}"> </div>
+    </div>
+    <br/>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Related issue 🛠
- closed #5 

## Work Description 📝

### 메일 인증번호 기능
- [x] 메일로 인증번호 전송
- [ ] 인증번호 검증
- [ ] 메일로 민증번호를 검증하지 않을 시, 회원가입이 되지 않는 기능까지 추가했습니다! 

### 비밀번호 수정 기능 
- [ ] 임시 비밀번호를 이메일로 전송합니다
- [ ] 임시 비밀번호로 로그인한 후, 비밀번호를 변경할 수 있습니다. 

### Jwt 관련 
- [ ] access & refresh Token 방식 변경
- [ ] token 응답을 무조건 Json으로 하도록 변경했습니다. 
- [ ] refresh Token은 무조건 Json으로 Request하게 변경했습니다. 

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 인증 코드 발송/검증 지원
  - 비밀번호 찾기(임시 비밀번호 메일 발송) 및 내 비밀번호 변경 기능 추가
  - 토큰 재발급 시 응답 본문으로 액세스/리프레시 토큰 반환

- 변경 사항
  - 로그아웃/재발급 요청에서 리프레시 토큰을 요청 본문으로 전달
  - 로그인 성공 시 토큰을 헤더 대신 응답 본문으로만 제공
  - 비밀번호 오류에 대한 에러 메시지 세분화

- 운영
  - 메일 발송 설정 활성화 및 이메일 템플릿 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->