### PR TITLE
[HotFix] jwt Token 응답 Http 상태코드 변경 

### DIFF
--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/handler/exception/CustomJsonAuthenticationFailureHandler.java
@@ -32,12 +32,12 @@ public class CustomJsonAuthenticationFailureHandler implements AuthenticationFai
 
         // 1) 아이디 없음
         if (ex instanceof UsernameNotFoundException) {
-            return ErrorCode.USER_NOT_FOUND;
+            return ErrorCode.SECURITY_UNAUTHORIZED;
         }
 
         // 2) 잘못된 자격 증명(값 누락/불일치)
         if (ex instanceof BadCredentialsException) {
-            return ErrorCode.INVALID_ID_OR_PASSWORD;
+            return ErrorCode.INVALID_EMAIL_OR_PASSWORD;
         }
 
         // 4) 요청 형식/메서드/파싱 문제 (JSON only 강제)

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/service/JwtService.java
@@ -1,24 +1,19 @@
 package com.WhoIsRoom.WhoIs_Server.domain.auth.service;
 
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.request.RefreshTokenRequest;
-import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response.LoginResponse;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.dto.response.ReissueResponse;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomAuthenticationException;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.exception.CustomJwtException;
 import com.WhoIsRoom.WhoIs_Server.domain.auth.util.JwtUtil;
 import com.WhoIsRoom.WhoIs_Server.global.common.redis.RedisService;
-import com.WhoIsRoom.WhoIs_Server.global.common.response.BaseResponse;
 import com.WhoIsRoom.WhoIs_Server.global.common.response.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.time.Duration;
 
 @Slf4j
@@ -53,7 +48,7 @@ public class JwtService {
         String refreshToken = tokenRequest.getRefreshToken();
         jwtUtil.validateToken(refreshToken);
         if (!"refresh".equals(jwtUtil.getTokenType(refreshToken))) {
-            throw new CustomJwtException(ErrorCode.INVALID_TOKEN_TYPE);
+            throw new CustomJwtException(ErrorCode.INVALID_REFRESH_TYPE);
         }
 
         deleteRefreshToken(refreshToken);
@@ -65,7 +60,7 @@ public class JwtService {
         String refreshToken = tokenRequest.getRefreshToken();
         jwtUtil.validateToken(refreshToken);
         if (!"refresh".equals(jwtUtil.getTokenType(refreshToken))) {
-            throw new CustomJwtException(ErrorCode.INVALID_TOKEN_TYPE);
+            throw new CustomJwtException(ErrorCode.INVALID_REFRESH_TYPE);
         }
         return reissueAndSendTokens(refreshToken);
     }
@@ -83,7 +78,7 @@ public class JwtService {
 
     private void deleteRefreshToken(String refreshToken){
         if(refreshToken == null){
-            throw new CustomJwtException(ErrorCode.EMPTY_REFRESH_HEADER);
+            throw new CustomJwtException(ErrorCode.INVALID_REFRESH_TYPE);
         }
         redisService.delete(refreshToken);
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/auth/util/JwtUtil.java
@@ -112,7 +112,7 @@ public class JwtUtil {
         } catch (IllegalArgumentException e) { // 토큰이 비어 있거나 Null
             throw new CustomJwtException(ErrorCode.EMPTY_AUTHORIZATION_HEADER);
         } catch (Exception e) { // 기타 예외 상황
-            throw new CustomJwtException(ErrorCode.SECURITY_INVALID_ACCESS_TOKEN);
+            throw new CustomJwtException(ErrorCode.SECURITY_INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/domain/user/service/UserService.java
@@ -58,7 +58,7 @@ public class UserService {
     @Transactional
     public void sendNewPassword(MailRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_MAIL_NOT_FOUND));
         String newPassword = mailService.sendPasswordMail(request);
         user.setPassword(passwordEncoder.encode(newPassword));
     }

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode{
     USER_NOT_FOUND(200, HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
     USER_DUPLICATE_EMAIL(201, HttpStatus.BAD_REQUEST.value(), "중복된 이메일의 사용자가 있습니다."),
     USER_DUPLICATE_NICKNAME(202, HttpStatus.BAD_REQUEST.value(), "중복된 닉네임의 사용자가 있습니다."),
+    USER_MAIL_NOT_FOUND(203, HttpStatus.NOT_FOUND.value(), "해당 이메일의 사용자를 찾을 수 없습니다."),
 
     // Club
     CLUB_NOT_FOUND(300, HttpStatus.NOT_FOUND.value(), "해당 동아리가 존재하지 않습니다."),
@@ -48,8 +49,7 @@ public enum ErrorCode{
     MALFORMED_TOKEN_TYPE(615, HttpStatus.UNAUTHORIZED.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
     INVALID_SIGNATURE_JWT(616, HttpStatus.UNAUTHORIZED.value(), "인증 시그니처가 올바르지 않습니다"),
     INVALID_EMAIL_OR_PASSWORD(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_PASSWORD(618, HttpStatus.UNAUTHORIZED.value(), "기존 비밀번호가 유효하지 않습니다"),
-    INVALID_EMAIL(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다.");
+    INVALID_PASSWORD(618, HttpStatus.UNAUTHORIZED.value(), "기존 비밀번호가 유효하지 않습니다");
 
     private final int code;
     private final int httpStatus;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -1,12 +1,8 @@
 package com.WhoIsRoom.WhoIs_Server.global.common.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
@@ -36,14 +32,14 @@ public enum ErrorCode{
 
     // Auth
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),
-    INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "토큰 타입이 유효하지 않습니다."),
     SECURITY_INVALID_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 token입니다."),
     SECURITY_INVALID_ACCESS_TOKEN(603, HttpStatus.UNAUTHORIZED.value(), "access token이 유효하지 않습니다."),
     SECURITY_ACCESS_DENIED(604, HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
-    EMPTY_REFRESH_HEADER(605, HttpStatus.BAD_REQUEST.value(), "refresh token이 필요합니다."),
+    INVALID_REFRESH_TYPE(605, HttpStatus.BAD_REQUEST.value(), "refresh token 타입이 유효하지 않습니다."),
+    INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "access token 타입이 유효하지 않습니다."),
     MAIL_SEND_FAILED(606, HttpStatus.BAD_REQUEST.value(), "메일 전송에 실패했습니다."),
-    INVALID_EMAIL_CODE(607, HttpStatus.BAD_REQUEST.value(), "인증 번호가 다릅니다."),
-    EXPIRED_EMAIL_CODE(608, HttpStatus.BAD_REQUEST.value(), "인증 번호가 만료되었거나 없습니다."),
+    INVALID_EMAIL_CODE(607, HttpStatus.UNAUTHORIZED.value(), "인증 번호가 다릅니다."),
+    EXPIRED_EMAIL_CODE(608, HttpStatus.UNAUTHORIZED.value(), "인증 번호가 만료되었거나 없습니다."),
     AUTHCODE_ALREADY_AUTHENTICATED(609, HttpStatus.BAD_REQUEST.value(), "이미 인증이 된 번호입니다."),
     AUTHCODE_UNAUTHORIZED(610, HttpStatus.UNAUTHORIZED.value(), "이메일 인증을 하지 않았습니다."),
     EMPTY_AUTHORIZATION_HEADER(612, HttpStatus.BAD_REQUEST.value(),"Authorization 헤더가 존재하지 않습니다."),
@@ -51,8 +47,9 @@ public enum ErrorCode{
     UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.UNAUTHORIZED.value(),"지원되지 않는 토큰 형식입니다."),
     MALFORMED_TOKEN_TYPE(615, HttpStatus.UNAUTHORIZED.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
     INVALID_SIGNATURE_JWT(616, HttpStatus.UNAUTHORIZED.value(), "인증 시그니처가 올바르지 않습니다"),
-    INVALID_ID_OR_PASSWORD(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_PASSWORD(618, HttpStatus.UNAUTHORIZED.value(), "기존 비밀번호가 유효하지 않습니다");
+    INVALID_EMAIL_OR_PASSWORD(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_PASSWORD(618, HttpStatus.UNAUTHORIZED.value(), "기존 비밀번호가 유효하지 않습니다"),
+    INVALID_EMAIL(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다.");
 
     private final int code;
     private final int httpStatus;

--- a/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
+++ b/src/main/java/com/WhoIsRoom/WhoIs_Server/global/common/response/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode{
     // Auth
     SECURITY_UNAUTHORIZED(600,HttpStatus.UNAUTHORIZED.value(), "인증 정보가 유효하지 않습니다"),
     INVALID_TOKEN_TYPE(601, HttpStatus.UNAUTHORIZED.value(), "토큰 타입이 유효하지 않습니다."),
-    SECURITY_INVALID_REFRESH_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "refresh token이 유효하지 않습니다."),
+    SECURITY_INVALID_TOKEN(602, HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 token입니다."),
     SECURITY_INVALID_ACCESS_TOKEN(603, HttpStatus.UNAUTHORIZED.value(), "access token이 유효하지 않습니다."),
     SECURITY_ACCESS_DENIED(604, HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."),
     EMPTY_REFRESH_HEADER(605, HttpStatus.BAD_REQUEST.value(), "refresh token이 필요합니다."),
@@ -38,14 +38,13 @@ public enum ErrorCode{
     EXPIRED_EMAIL_CODE(608, HttpStatus.BAD_REQUEST.value(), "인증 번호가 만료되었거나 없습니다."),
     AUTHCODE_ALREADY_AUTHENTICATED(609, HttpStatus.BAD_REQUEST.value(), "이미 인증이 된 번호입니다."),
     AUTHCODE_UNAUTHORIZED(610, HttpStatus.UNAUTHORIZED.value(), "이메일 인증을 하지 않았습니다."),
-    LOGIN_FAILED(611, HttpStatus.BAD_REQUEST.value(), "이메일 혹은 비밀번호가 올바르지 않습니다."),
     EMPTY_AUTHORIZATION_HEADER(612, HttpStatus.BAD_REQUEST.value(),"Authorization 헤더가 존재하지 않습니다."),
-    EXPIRED_ACCESS_TOKEN(613, HttpStatus.BAD_REQUEST.value(), "이미 만료된 Access 토큰입니다."),
-    UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.BAD_REQUEST.value(),"지원되지 않는 토큰 형식입니다."),
-    MALFORMED_TOKEN_TYPE(615, HttpStatus.BAD_REQUEST.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
-    INVALID_SIGNATURE_JWT(616, HttpStatus.BAD_REQUEST.value(), "인증 시그니처가 올바르지 않습니다"),
-    INVALID_ID_OR_PASSWORD(617, HttpStatus.BAD_REQUEST.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
-    INVALID_PASSWORD(618, HttpStatus.BAD_REQUEST.value(), "기존 비밀번호가 유효하지 않습니다");
+    EXPIRED_ACCESS_TOKEN(613, HttpStatus.UNAUTHORIZED.value(), "이미 만료된 Access 토큰입니다."),
+    UNSUPPORTED_TOKEN_TYPE(614, HttpStatus.UNAUTHORIZED.value(),"지원되지 않는 토큰 형식입니다."),
+    MALFORMED_TOKEN_TYPE(615, HttpStatus.UNAUTHORIZED.value(),"인증 토큰이 올바르게 구성되지 않았습니다."),
+    INVALID_SIGNATURE_JWT(616, HttpStatus.UNAUTHORIZED.value(), "인증 시그니처가 올바르지 않습니다"),
+    INVALID_ID_OR_PASSWORD(617, HttpStatus.UNAUTHORIZED.value(), "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_PASSWORD(618, HttpStatus.UNAUTHORIZED.value(), "기존 비밀번호가 유효하지 않습니다");
 
     private final int code;
     private final int httpStatus;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Related issue 🛠
- closed #이슈넘버

## Work Description 📝

### Token이 만료되거나 유효하지 않은 경우, Http Status를 400으로 반환 했지만, 401 반환이 올바른 것 같아서 이를 수정했습니다!

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능: 없음
- 버그 수정
  - 인증/토큰 관련 오류의 HTTP 상태를 400 → 401로 조정하여 만료된 토큰·잘못된 서명 등에서 올바른 Unauthorized 응답을 반환합니다.
  - 토큰 검증 및 인증 실패 시 일관된 오류 응답을 제공합니다.
  - 비밀번호 재발급 시 존재하지 않는 이메일에 대해 명확한 오류를 반환합니다.
- 리팩터링
  - 인증 오류 코드 명칭 및 일부 불필요 항목을 정리하여 응답 일관성 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->